### PR TITLE
Document messenger configuration and add functional bus tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# cqrs
+# SomeWork CQRS Bundle
+
+The bundle builds on top of Symfony Messenger. Configure dedicated command, query, and event buses so the provided facades can route messages deterministically across environments.
+
+## Messenger configuration
+
+### Shared defaults (`config/packages/messenger.yaml`)
+
+```yaml
+framework:
+    messenger:
+        default_bus: messenger.bus.commands
+        buses:
+            messenger.bus.commands: ~
+            messenger.bus.commands_async:
+                default_middleware:
+                    enabled: true
+            messenger.bus.queries: ~
+            messenger.bus.events: ~
+            messenger.bus.events_async:
+                default_middleware:
+                    enabled: true
+```
+
+### CQRS bundle defaults (`config/packages/somework_cqrs.yaml`)
+
+```yaml
+somework_cqrs:
+    default_bus: messenger.bus.commands
+    buses:
+        command: messenger.bus.commands
+        command_async: messenger.bus.commands_async
+        query: messenger.bus.queries
+        event: messenger.bus.events
+        event_async: messenger.bus.events_async
+```
+
+### Production transport setup (`config/packages/prod/messenger.yaml`)
+
+Configure real transports and routing so asynchronous commands and events leave the HTTP process.
+
+```yaml
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    auto_setup: false
+        routing:
+            'App\\Application\\Command\\GenerateReportCommand': async
+            'App\\Domain\\Event\\TaskCreated': async
+```
+
+Run the worker with `bin/console messenger:consume async` to process queued messages.
+
+### Development overrides (`config/packages/dev/messenger.yaml`)
+
+Point the async transport at a developer-friendly backend (for example Doctrine or Redis) and allow Messenger to create it on the fly:
+
+```yaml
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: '%env(resolve:MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    auto_setup: true
+```
+
+### Test overrides (`config/packages/test/messenger.yaml`)
+
+Use an in-memory transport so functional tests can assert on dispatched messages without spawning workers.
+
+```yaml
+framework:
+    messenger:
+        transports:
+            async: 'in-memory://'
+        routing:
+            'App\\Application\\Command\\GenerateReportCommand': async
+            'App\\Domain\\Event\\TaskCreated': async
+```
+
+With these settings the command, event, and query bus facades provided by the bundle transparently adapt to each environment.

--- a/config/services.php
+++ b/config/services.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use SomeWork\CqrsBundle\Bus\CommandBus;
+use SomeWork\CqrsBundle\Bus\EventBus;
+use SomeWork\CqrsBundle\Bus\QueryBus;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $configurator): void {
@@ -13,4 +16,8 @@ return static function (ContainerConfigurator $configurator): void {
     $services
         ->load('SomeWork\\CqrsBundle\\', '../src/*')
         ->exclude('../src/DependencyInjection');
+
+    $services->set(CommandBus::class)->public();
+    $services->set(EventBus::class)->public();
+    $services->set(QueryBus::class)->public();
 };

--- a/src/Attribute/AsCommandHandler.php
+++ b/src/Attribute/AsCommandHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Attribute;
+
+use Attribute;
+use SomeWork\CqrsBundle\Contract\Command;
+
+/**
+ * Attribute to mark a service as a command handler.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class AsCommandHandler
+{
+    /**
+     * @param class-string<Command> $command
+     * @param non-empty-string|null $bus
+     */
+    public function __construct(
+        public readonly string $command,
+        public readonly ?string $bus = null,
+    ) {
+    }
+}

--- a/src/Attribute/AsEventHandler.php
+++ b/src/Attribute/AsEventHandler.php
@@ -14,7 +14,7 @@ use SomeWork\CqrsBundle\Contract\Event;
 final class AsEventHandler
 {
     /**
-     * @param class-string<Event> $event
+     * @param class-string<Event>   $event
      * @param non-empty-string|null $bus
      */
     public function __construct(

--- a/src/Attribute/AsEventHandler.php
+++ b/src/Attribute/AsEventHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Attribute;
+
+use Attribute;
+use SomeWork\CqrsBundle\Contract\Event;
+
+/**
+ * Attribute to mark a service as an event handler.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class AsEventHandler
+{
+    /**
+     * @param class-string<Event> $event
+     * @param non-empty-string|null $bus
+     */
+    public function __construct(
+        public readonly string $event,
+        public readonly ?string $bus = null,
+    ) {
+    }
+}

--- a/src/Attribute/AsQueryHandler.php
+++ b/src/Attribute/AsQueryHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Attribute;
+
+use Attribute;
+use SomeWork\CqrsBundle\Contract\Query;
+
+/**
+ * Attribute to mark a service as a query handler.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class AsQueryHandler
+{
+    /**
+     * @param class-string<Query> $query
+     * @param non-empty-string|null $bus
+     */
+    public function __construct(
+        public readonly string $query,
+        public readonly ?string $bus = null,
+    ) {
+    }
+}

--- a/src/Attribute/AsQueryHandler.php
+++ b/src/Attribute/AsQueryHandler.php
@@ -14,7 +14,7 @@ use SomeWork\CqrsBundle\Contract\Query;
 final class AsQueryHandler
 {
     /**
-     * @param class-string<Query> $query
+     * @param class-string<Query>   $query
      * @param non-empty-string|null $bus
      */
     public function __construct(

--- a/src/Bus/CommandBus.php
+++ b/src/Bus/CommandBus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Bus;
+
+use SomeWork\CqrsBundle\Contract\Command;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Dispatches commands through configured Messenger buses.
+ */
+final class CommandBus
+{
+    public function __construct(
+        private readonly MessageBusInterface $syncBus,
+        private readonly ?MessageBusInterface $asyncBus = null,
+    ) {
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatch(Command $command, DispatchMode $mode = DispatchMode::SYNC, StampInterface ...$stamps): Envelope
+    {
+        return $this->selectBus($mode)->dispatch($command, $stamps);
+    }
+
+    private function selectBus(DispatchMode $mode): MessageBusInterface
+    {
+        if (DispatchMode::ASYNC === $mode) {
+            if (!$this->asyncBus instanceof MessageBusInterface) {
+                throw new \LogicException('Asynchronous command bus is not configured.');
+            }
+
+            return $this->asyncBus;
+        }
+
+        return $this->syncBus;
+    }
+}

--- a/src/Bus/DispatchMode.php
+++ b/src/Bus/DispatchMode.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Bus;
+
+/**
+ * Defines how a message should be dispatched by a bus.
+ */
+enum DispatchMode: string
+{
+    case SYNC = 'sync';
+    case ASYNC = 'async';
+}

--- a/src/Bus/EventBus.php
+++ b/src/Bus/EventBus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Bus;
+
+use SomeWork\CqrsBundle\Contract\Event;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Dispatches domain events through Messenger buses.
+ */
+final class EventBus
+{
+    public function __construct(
+        private readonly MessageBusInterface $syncBus,
+        private readonly ?MessageBusInterface $asyncBus = null,
+    ) {
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatch(Event $event, DispatchMode $mode = DispatchMode::SYNC, StampInterface ...$stamps): Envelope
+    {
+        return $this->selectBus($mode)->dispatch($event, $stamps);
+    }
+
+    private function selectBus(DispatchMode $mode): MessageBusInterface
+    {
+        if (DispatchMode::ASYNC === $mode) {
+            if (!$this->asyncBus instanceof MessageBusInterface) {
+                throw new \LogicException('Asynchronous event bus is not configured.');
+            }
+
+            return $this->asyncBus;
+        }
+
+        return $this->syncBus;
+    }
+}

--- a/src/Bus/QueryBus.php
+++ b/src/Bus/QueryBus.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Bus;
+
+use SomeWork\CqrsBundle\Contract\Query;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Dispatches queries and returns the handler result.
+ */
+final class QueryBus
+{
+    public function __construct(private readonly MessageBusInterface $bus)
+    {
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function ask(Query $query, StampInterface ...$stamps): mixed
+    {
+        $envelope = $this->bus->dispatch($query, $stamps);
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        if (!$handled instanceof HandledStamp) {
+            throw new \LogicException('Query was not handled by any handler.');
+        }
+
+        return $handled->getResult();
+    }
+}

--- a/src/Contract/Command.php
+++ b/src/Contract/Command.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * Marker interface for command messages.
+ *
+ * Commands are immutable data transfer objects (DTOs) describing an intention to
+ * change state. They MUST NOT perform business logic and SHOULD expose their
+ * data via explicit accessors.
+ *
+ * @psalm-immutable
+ */
+interface Command
+{
+}

--- a/src/Contract/CommandHandler.php
+++ b/src/Contract/CommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * @template TCommand of Command
+ */
+interface CommandHandler
+{
+    /**
+     * Handle the given command.
+     *
+     * Implementations SHOULD be stateless services. They MUST NOT mutate the
+     * provided command instance.
+     *
+     * @param TCommand $command
+     */
+    public function __invoke(Command $command): mixed;
+}

--- a/src/Contract/EnvelopeAware.php
+++ b/src/Contract/EnvelopeAware.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Allows handlers to receive the current Messenger envelope.
+ */
+interface EnvelopeAware
+{
+    public function setEnvelope(Envelope $envelope): void;
+}

--- a/src/Contract/EnvelopeAwareTrait.php
+++ b/src/Contract/EnvelopeAwareTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Provides storage for the Messenger envelope currently being handled.
+ */
+trait EnvelopeAwareTrait
+{
+    private ?Envelope $envelope = null;
+
+    public function setEnvelope(Envelope $envelope): void
+    {
+        $this->envelope = $envelope;
+    }
+
+    protected function getEnvelope(): Envelope
+    {
+        if (!$this->envelope instanceof Envelope) {
+            throw new \LogicException('Messenger envelope has not been set.');
+        }
+
+        return $this->envelope;
+    }
+}

--- a/src/Contract/Event.php
+++ b/src/Contract/Event.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * Marker interface for event messages.
+ *
+ * Events are immutable records describing something that already happened.
+ * They MUST NOT contain behavior and SHOULD expose their data via accessors.
+ *
+ * @psalm-immutable
+ */
+interface Event
+{
+}

--- a/src/Contract/EventHandler.php
+++ b/src/Contract/EventHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * @template TEvent of Event
+ */
+interface EventHandler
+{
+    /**
+     * Handle the given event.
+     *
+     * Implementations SHOULD be stateless services. They MUST NOT mutate the
+     * provided event instance.
+     *
+     * @param TEvent $event
+     */
+    public function __invoke(Event $event): void;
+}

--- a/src/Contract/Query.php
+++ b/src/Contract/Query.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * Marker interface for query messages.
+ *
+ * Queries are immutable read-only data transfer objects (DTOs) that describe
+ * the data a caller wishes to retrieve. They MUST NOT contain business logic
+ * and SHOULD provide explicit accessors for their payload.
+ *
+ * @psalm-immutable
+ */
+interface Query
+{
+}

--- a/src/Contract/QueryHandler.php
+++ b/src/Contract/QueryHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * @template TQuery of Query
+ * @template TResult
+ */
+interface QueryHandler
+{
+    /**
+     * Execute the query and return the result.
+     *
+     * Implementations SHOULD be stateless services. They MUST NOT mutate the
+     * provided query instance.
+     *
+     * @param TQuery $query
+     *
+     * @return TResult
+     */
+    public function __invoke(Query $query): mixed;
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,6 +27,52 @@ final class Configuration implements ConfigurationInterface
             ->info('Default message bus service id to use when dispatching messages.');
         $defaultBus->end();
 
+        $buses = $children->arrayNode('buses');
+        $buses
+            ->addDefaultsIfNotSet()
+            ->info('Per-message-type bus service ids used by the CQRS facades.');
+
+        /** @var ArrayNodeDefinition $busesChildren */
+        $busesChildren = $buses->children();
+
+        /** @var ScalarNodeDefinition $commandBus */
+        $commandBus = $busesChildren->scalarNode('command');
+        $commandBus
+            ->defaultNull()
+            ->info('Synchronous command bus service id. Defaults to the Messenger default bus.');
+        $commandBus->end();
+
+        /** @var ScalarNodeDefinition $commandAsyncBus */
+        $commandAsyncBus = $busesChildren->scalarNode('command_async');
+        $commandAsyncBus
+            ->defaultNull()
+            ->info('Asynchronous command bus service id. Leave null to disable async dispatch.');
+        $commandAsyncBus->end();
+
+        /** @var ScalarNodeDefinition $queryBus */
+        $queryBus = $busesChildren->scalarNode('query');
+        $queryBus
+            ->defaultNull()
+            ->info('Query bus service id. Defaults to the Messenger default bus.');
+        $queryBus->end();
+
+        /** @var ScalarNodeDefinition $eventBus */
+        $eventBus = $busesChildren->scalarNode('event');
+        $eventBus
+            ->defaultNull()
+            ->info('Synchronous event bus service id. Defaults to the Messenger default bus.');
+        $eventBus->end();
+
+        /** @var ScalarNodeDefinition $eventAsyncBus */
+        $eventAsyncBus = $busesChildren->scalarNode('event_async');
+        $eventAsyncBus
+            ->defaultNull()
+            ->info('Asynchronous event bus service id. Leave null to disable async dispatch.');
+        $eventAsyncBus->end();
+
+        $busesChildren->end();
+        $buses->end();
+
         return $treeBuilder;
     }
 }

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\DependencyInjection;
 
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Attribute\AsEventHandler;
+use SomeWork\CqrsBundle\Attribute\AsQueryHandler;
+use SomeWork\CqrsBundle\Bus\CommandBus;
+use SomeWork\CqrsBundle\Bus\EventBus;
+use SomeWork\CqrsBundle\Bus\QueryBus;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class CqrsExtension extends Extension
 {
@@ -19,14 +28,101 @@ final class CqrsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('somework_cqrs.default_bus', $config['default_bus']);
+        $defaultBusId = $config['default_bus'] ?? 'messenger.default_bus';
+        $container->setParameter('somework_cqrs.default_bus', $defaultBusId);
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
+
+        $this->registerHandlerAttributes($container);
+        $this->configureBusServices($container, $config['buses'], $defaultBusId);
     }
 
     public function getAlias(): string
     {
         return 'somework_cqrs';
+    }
+
+    /**
+     * @param array{
+     *     command?: string|null,
+     *     command_async?: string|null,
+     *     query?: string|null,
+     *     event?: string|null,
+     *     event_async?: string|null,
+     * } $buses
+     */
+    private function configureBusServices(ContainerBuilder $container, array $buses, string $defaultBusId): void
+    {
+        if ($container->hasDefinition(CommandBus::class)) {
+            $commandBusDefinition = $container->getDefinition(CommandBus::class);
+            $commandBusDefinition->setArgument('$syncBus', new Reference($buses['command'] ?? $defaultBusId));
+
+            $commandAsync = $buses['command_async'] ?? null;
+            if (null !== $commandAsync) {
+                $commandBusDefinition->setArgument('$asyncBus', new Reference($commandAsync, ContainerInterface::NULL_ON_INVALID_REFERENCE));
+            } else {
+                $commandBusDefinition->setArgument('$asyncBus', null);
+            }
+        }
+
+        if ($container->hasDefinition(QueryBus::class)) {
+            $queryBusDefinition = $container->getDefinition(QueryBus::class);
+            $queryBusDefinition->setArgument('$bus', new Reference($buses['query'] ?? $defaultBusId));
+        }
+
+        if ($container->hasDefinition(EventBus::class)) {
+            $eventBusDefinition = $container->getDefinition(EventBus::class);
+            $eventBusDefinition->setArgument('$syncBus', new Reference($buses['event'] ?? $defaultBusId));
+
+            $eventAsync = $buses['event_async'] ?? null;
+            if (null !== $eventAsync) {
+                $eventBusDefinition->setArgument('$asyncBus', new Reference($eventAsync, ContainerInterface::NULL_ON_INVALID_REFERENCE));
+            } else {
+                $eventBusDefinition->setArgument('$asyncBus', null);
+            }
+        }
+    }
+
+    private function registerHandlerAttributes(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            AsCommandHandler::class,
+            static function (ChildDefinition $definition, AsCommandHandler $attribute): void {
+                $definition->addTag(
+                    'messenger.message_handler',
+                    array_filter([
+                        'handles' => $attribute->command,
+                        'bus' => $attribute->bus,
+                    ], static fn ($value): bool => null !== $value)
+                );
+            }
+        );
+
+        $container->registerAttributeForAutoconfiguration(
+            AsQueryHandler::class,
+            static function (ChildDefinition $definition, AsQueryHandler $attribute): void {
+                $definition->addTag(
+                    'messenger.message_handler',
+                    array_filter([
+                        'handles' => $attribute->query,
+                        'bus' => $attribute->bus,
+                    ], static fn ($value): bool => null !== $value)
+                );
+            }
+        );
+
+        $container->registerAttributeForAutoconfiguration(
+            AsEventHandler::class,
+            static function (ChildDefinition $definition, AsEventHandler $attribute): void {
+                $definition->addTag(
+                    'messenger.message_handler',
+                    array_filter([
+                        'handles' => $attribute->event,
+                        'bus' => $attribute->bus,
+                    ], static fn ($value): bool => null !== $value)
+                );
+            }
+        );
     }
 }

--- a/src/Handler/AbstractCommandHandler.php
+++ b/src/Handler/AbstractCommandHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Handler;
+
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\CommandHandler;
+use SomeWork\CqrsBundle\Contract\EnvelopeAware;
+use SomeWork\CqrsBundle\Contract\EnvelopeAwareTrait;
+
+/**
+ * Base class for command handlers that exposes a typed {@see handle()} method.
+ *
+ * @template TCommand of Command
+ */
+abstract class AbstractCommandHandler implements CommandHandler, EnvelopeAware
+{
+    use EnvelopeAwareTrait;
+
+    final public function __invoke(Command $command): mixed
+    {
+        return $this->handle($command);
+    }
+
+    /**
+     * @param TCommand $command
+     */
+    abstract protected function handle(Command $command): mixed;
+}

--- a/src/Handler/AbstractEventHandler.php
+++ b/src/Handler/AbstractEventHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Handler;
+
+use SomeWork\CqrsBundle\Contract\EnvelopeAware;
+use SomeWork\CqrsBundle\Contract\EnvelopeAwareTrait;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Contract\EventHandler;
+
+/**
+ * Base class for event handlers that exposes a typed {@see on()} method.
+ *
+ * @template TEvent of Event
+ */
+abstract class AbstractEventHandler implements EventHandler, EnvelopeAware
+{
+    use EnvelopeAwareTrait;
+
+    final public function __invoke(Event $event): void
+    {
+        $this->on($event);
+    }
+
+    /**
+     * @param TEvent $event
+     */
+    abstract protected function on(Event $event): void;
+}

--- a/src/Handler/AbstractQueryHandler.php
+++ b/src/Handler/AbstractQueryHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Handler;
+
+use SomeWork\CqrsBundle\Contract\EnvelopeAware;
+use SomeWork\CqrsBundle\Contract\EnvelopeAwareTrait;
+use SomeWork\CqrsBundle\Contract\Query;
+use SomeWork\CqrsBundle\Contract\QueryHandler;
+
+/**
+ * Base class for query handlers that exposes a typed {@see fetch()} method.
+ *
+ * @template TQuery of Query
+ * @template TResult
+ */
+abstract class AbstractQueryHandler implements QueryHandler, EnvelopeAware
+{
+    use EnvelopeAwareTrait;
+
+    final public function __invoke(Query $query): mixed
+    {
+        return $this->fetch($query);
+    }
+
+    /**
+     * @param TQuery $query
+     *
+     * @return TResult
+     */
+    abstract protected function fetch(Query $query): mixed;
+}

--- a/src/Stamp/MessageMetadataStamp.php
+++ b/src/Stamp/MessageMetadataStamp.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 final class MessageMetadataStamp implements StampInterface
 {
     /**
-     * @param non-empty-string $correlationId
+     * @param non-empty-string     $correlationId
      * @param array<string, mixed> $extras
      */
     public function __construct(

--- a/src/Stamp/MessageMetadataStamp.php
+++ b/src/Stamp/MessageMetadataStamp.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Carries metadata such as correlation identifiers for Messenger messages.
+ */
+final class MessageMetadataStamp implements StampInterface
+{
+    /**
+     * @param non-empty-string $correlationId
+     * @param array<string, mixed> $extras
+     */
+    public function __construct(
+        private readonly string $correlationId,
+        private readonly array $extras = [],
+    ) {
+        if ('' === $this->correlationId) {
+            throw new \InvalidArgumentException('Correlation ID cannot be empty.');
+        }
+    }
+
+    public static function createWithRandomCorrelationId(array $extras = []): self
+    {
+        return new self(self::generateCorrelationId(), $extras);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getCorrelationId(): string
+    {
+        return $this->correlationId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtras(): array
+    {
+        return $this->extras;
+    }
+
+    public function withCorrelationId(string $correlationId): self
+    {
+        return new self($correlationId, $this->extras);
+    }
+
+    public function withExtra(string $key, mixed $value): self
+    {
+        $extras = $this->extras;
+        $extras[$key] = $value;
+
+        return new self($this->correlationId, $extras);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function generateCorrelationId(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Bus;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\CommandBus;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\Command;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CommandBusTest extends TestCase
+{
+    public function test_dispatch_uses_sync_bus_by_default(): void
+    {
+        $command = $this->createStub(Command::class);
+        $envelope = new Envelope($command);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($command, [])
+            ->willReturn($envelope);
+
+        $bus = new CommandBus($syncBus);
+
+        self::assertSame($envelope, $bus->dispatch($command));
+    }
+
+    public function test_dispatch_to_async_bus_when_configured(): void
+    {
+        $command = $this->createStub(Command::class);
+        $envelope = new Envelope($command);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($command, [])
+            ->willReturn($envelope);
+
+        $bus = new CommandBus($syncBus, $asyncBus);
+
+        self::assertSame($envelope, $bus->dispatch($command, DispatchMode::ASYNC));
+    }
+
+    public function test_async_dispatch_without_bus_throws_exception(): void
+    {
+        $command = $this->createStub(Command::class);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+
+        $bus = new CommandBus($syncBus);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Asynchronous command bus is not configured.');
+
+        $bus->dispatch($command, DispatchMode::ASYNC);
+    }
+}

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Bus;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Bus\EventBus;
+use SomeWork\CqrsBundle\Contract\Event;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class EventBusTest extends TestCase
+{
+    public function test_dispatch_uses_sync_bus_by_default(): void
+    {
+        $event = $this->createStub(Event::class);
+        $envelope = new Envelope($event);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [])
+            ->willReturn($envelope);
+
+        $bus = new EventBus($syncBus);
+
+        self::assertSame($envelope, $bus->dispatch($event));
+    }
+
+    public function test_dispatch_to_async_bus_when_configured(): void
+    {
+        $event = $this->createStub(Event::class);
+        $envelope = new Envelope($event);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [])
+            ->willReturn($envelope);
+
+        $bus = new EventBus($syncBus, $asyncBus);
+
+        self::assertSame($envelope, $bus->dispatch($event, DispatchMode::ASYNC));
+    }
+
+    public function test_async_dispatch_without_bus_throws_exception(): void
+    {
+        $event = $this->createStub(Event::class);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+
+        $bus = new EventBus($syncBus);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Asynchronous event bus is not configured.');
+
+        $bus->dispatch($event, DispatchMode::ASYNC);
+    }
+}

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Bus;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\QueryBus;
+use SomeWork\CqrsBundle\Contract\Query;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+
+final class QueryBusTest extends TestCase
+{
+    public function test_ask_returns_handled_result(): void
+    {
+        $query = $this->createStub(Query::class);
+
+        $handled = new HandledStamp('value', 'handler');
+        $envelope = (new Envelope($query))->with($handled);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with($query, [])
+            ->willReturn($envelope);
+
+        $queryBus = new QueryBus($bus);
+
+        self::assertSame('value', $queryBus->ask($query));
+    }
+
+    public function test_ask_without_result_throws_exception(): void
+    {
+        $query = $this->createStub(Query::class);
+        $envelope = new Envelope($query);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with($query, [])
+            ->willReturn($envelope);
+
+        $queryBus = new QueryBus($bus);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Query was not handled by any handler.');
+
+        $queryBus->ask($query);
+    }
+}

--- a/tests/Fixture/Handler/AsyncProjectionHandler.php
+++ b/tests/Fixture/Handler/AsyncProjectionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Handler;
+
+use SomeWork\CqrsBundle\Attribute\AsEventHandler;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Handler\AbstractEventHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+
+#[AsEventHandler(event: TaskCreatedEvent::class, bus: 'messenger.bus.events_async')]
+final class AsyncProjectionHandler extends AbstractEventHandler
+{
+    public function __construct(private readonly TaskRecorder $recorder)
+    {
+    }
+
+    /**
+     * @param TaskCreatedEvent $event
+     */
+    protected function on(Event $event): void
+    {
+        \assert($event instanceof TaskCreatedEvent);
+
+        $this->recorder->recordAsyncEvent($event->taskId);
+    }
+}

--- a/tests/Fixture/Handler/AsyncProjectionHandler.php
+++ b/tests/Fixture/Handler/AsyncProjectionHandler.php
@@ -10,6 +10,8 @@ use SomeWork\CqrsBundle\Handler\AbstractEventHandler;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
 
+use function assert;
+
 #[AsEventHandler(event: TaskCreatedEvent::class, bus: 'messenger.bus.events_async')]
 final class AsyncProjectionHandler extends AbstractEventHandler
 {
@@ -22,7 +24,7 @@ final class AsyncProjectionHandler extends AbstractEventHandler
      */
     protected function on(Event $event): void
     {
-        \assert($event instanceof TaskCreatedEvent);
+        assert($event instanceof TaskCreatedEvent);
 
         $this->recorder->recordAsyncEvent($event->taskId);
     }

--- a/tests/Fixture/Handler/CreateTaskHandler.php
+++ b/tests/Fixture/Handler/CreateTaskHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Handler;
+
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Handler\AbstractCommandHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+
+#[AsCommandHandler(command: CreateTaskCommand::class)]
+final class CreateTaskHandler extends AbstractCommandHandler
+{
+    public function __construct(private readonly TaskRecorder $recorder)
+    {
+    }
+
+    /**
+     * @param CreateTaskCommand $command
+     */
+    protected function handle(Command $command): mixed
+    {
+        \assert($command instanceof CreateTaskCommand);
+
+        $this->recorder->recordTask($command->id, $command->name);
+
+        return null;
+    }
+}

--- a/tests/Fixture/Handler/CreateTaskHandler.php
+++ b/tests/Fixture/Handler/CreateTaskHandler.php
@@ -10,6 +10,8 @@ use SomeWork\CqrsBundle\Handler\AbstractCommandHandler;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
 use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
 
+use function assert;
+
 #[AsCommandHandler(command: CreateTaskCommand::class)]
 final class CreateTaskHandler extends AbstractCommandHandler
 {
@@ -22,7 +24,7 @@ final class CreateTaskHandler extends AbstractCommandHandler
      */
     protected function handle(Command $command): mixed
     {
-        \assert($command instanceof CreateTaskCommand);
+        assert($command instanceof CreateTaskCommand);
 
         $this->recorder->recordTask($command->id, $command->name);
 

--- a/tests/Fixture/Handler/FindTaskHandler.php
+++ b/tests/Fixture/Handler/FindTaskHandler.php
@@ -10,6 +10,8 @@ use SomeWork\CqrsBundle\Handler\AbstractQueryHandler;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
 use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
 
+use function assert;
+
 #[AsQueryHandler(query: FindTaskQuery::class, bus: 'messenger.bus.queries')]
 final class FindTaskHandler extends AbstractQueryHandler
 {
@@ -22,7 +24,7 @@ final class FindTaskHandler extends AbstractQueryHandler
      */
     protected function fetch(Query $query): mixed
     {
-        \assert($query instanceof FindTaskQuery);
+        assert($query instanceof FindTaskQuery);
 
         return $this->recorder->task($query->taskId);
     }

--- a/tests/Fixture/Handler/FindTaskHandler.php
+++ b/tests/Fixture/Handler/FindTaskHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Handler;
+
+use SomeWork\CqrsBundle\Attribute\AsQueryHandler;
+use SomeWork\CqrsBundle\Contract\Query;
+use SomeWork\CqrsBundle\Handler\AbstractQueryHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+
+#[AsQueryHandler(query: FindTaskQuery::class, bus: 'messenger.bus.queries')]
+final class FindTaskHandler extends AbstractQueryHandler
+{
+    public function __construct(private readonly TaskRecorder $recorder)
+    {
+    }
+
+    /**
+     * @param FindTaskQuery $query
+     */
+    protected function fetch(Query $query): mixed
+    {
+        \assert($query instanceof FindTaskQuery);
+
+        return $this->recorder->task($query->taskId);
+    }
+}

--- a/tests/Fixture/Handler/GenerateReportHandler.php
+++ b/tests/Fixture/Handler/GenerateReportHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Handler;
+
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Handler\AbstractCommandHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\GenerateReportCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+
+#[AsCommandHandler(command: GenerateReportCommand::class, bus: 'messenger.bus.commands_async')]
+final class GenerateReportHandler extends AbstractCommandHandler
+{
+    public function __construct(private readonly TaskRecorder $recorder)
+    {
+    }
+
+    /**
+     * @param GenerateReportCommand $command
+     */
+    protected function handle(Command $command): mixed
+    {
+        \assert($command instanceof GenerateReportCommand);
+
+        $this->recorder->recordReport($command->reportId);
+
+        return null;
+    }
+}

--- a/tests/Fixture/Handler/GenerateReportHandler.php
+++ b/tests/Fixture/Handler/GenerateReportHandler.php
@@ -10,6 +10,8 @@ use SomeWork\CqrsBundle\Handler\AbstractCommandHandler;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\GenerateReportCommand;
 use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
 
+use function assert;
+
 #[AsCommandHandler(command: GenerateReportCommand::class, bus: 'messenger.bus.commands_async')]
 final class GenerateReportHandler extends AbstractCommandHandler
 {
@@ -22,7 +24,7 @@ final class GenerateReportHandler extends AbstractCommandHandler
      */
     protected function handle(Command $command): mixed
     {
-        \assert($command instanceof GenerateReportCommand);
+        assert($command instanceof GenerateReportCommand);
 
         $this->recorder->recordReport($command->reportId);
 

--- a/tests/Fixture/Handler/TaskNotificationHandler.php
+++ b/tests/Fixture/Handler/TaskNotificationHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Handler;
+
+use SomeWork\CqrsBundle\Attribute\AsEventHandler;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Handler\AbstractEventHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+
+#[AsEventHandler(event: TaskCreatedEvent::class, bus: 'messenger.bus.events')]
+final class TaskNotificationHandler extends AbstractEventHandler
+{
+    public function __construct(private readonly TaskRecorder $recorder)
+    {
+    }
+
+    /**
+     * @param TaskCreatedEvent $event
+     */
+    protected function on(Event $event): void
+    {
+        \assert($event instanceof TaskCreatedEvent);
+
+        $this->recorder->recordEvent($event->taskId);
+    }
+}

--- a/tests/Fixture/Handler/TaskNotificationHandler.php
+++ b/tests/Fixture/Handler/TaskNotificationHandler.php
@@ -10,6 +10,8 @@ use SomeWork\CqrsBundle\Handler\AbstractEventHandler;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
 
+use function assert;
+
 #[AsEventHandler(event: TaskCreatedEvent::class, bus: 'messenger.bus.events')]
 final class TaskNotificationHandler extends AbstractEventHandler
 {
@@ -22,7 +24,7 @@ final class TaskNotificationHandler extends AbstractEventHandler
      */
     protected function on(Event $event): void
     {
-        \assert($event instanceof TaskCreatedEvent);
+        assert($event instanceof TaskCreatedEvent);
 
         $this->recorder->recordEvent($event->taskId);
     }

--- a/tests/Fixture/Kernel/TestKernel.php
+++ b/tests/Fixture/Kernel/TestKernel.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Kernel;
+
+use SomeWork\CqrsBundle\SomeWorkCqrsBundle;
+use SomeWork\CqrsBundle\Tests\Fixture\Handler\AsyncProjectionHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Handler\CreateTaskHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Handler\FindTaskHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Handler\GenerateReportHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Handler\TaskNotificationHandler;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+final class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+        yield new SomeWorkCqrsBundle();
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'secret' => 'test-secret',
+            'http_method_override' => false,
+            'test' => true,
+            'messenger' => [
+                'default_bus' => 'messenger.bus.commands',
+                'buses' => [
+                    'messenger.bus.commands' => null,
+                    'messenger.bus.commands_async' => [
+                        'default_middleware' => ['enabled' => true],
+                    ],
+                    'messenger.bus.queries' => null,
+                    'messenger.bus.events' => null,
+                    'messenger.bus.events_async' => [
+                        'default_middleware' => ['enabled' => true],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->extension('somework_cqrs', [
+            'default_bus' => 'messenger.bus.commands',
+            'buses' => [
+                'command' => 'messenger.bus.commands',
+                'command_async' => 'messenger.bus.commands_async',
+                'query' => 'messenger.bus.queries',
+                'event' => 'messenger.bus.events',
+                'event_async' => 'messenger.bus.events_async',
+            ],
+        ]);
+
+        $services = $container->services()
+            ->defaults()
+            ->autowire()
+            ->autoconfigure();
+
+        $services->set(TaskRecorder::class);
+        $services->set(CreateTaskHandler::class);
+        $services->set(GenerateReportHandler::class);
+        $services->set(FindTaskHandler::class);
+        $services->set(TaskNotificationHandler::class);
+        $services->set(AsyncProjectionHandler::class);
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        // No routes required for the functional test kernel.
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/cqrs_bundle/cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/cqrs_bundle/log';
+    }
+}

--- a/tests/Fixture/Message/CreateTaskCommand.php
+++ b/tests/Fixture/Message/CreateTaskCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Command;
+
+/**
+ * Immutable command representing a request to create a task aggregate.
+ */
+final class CreateTaskCommand implements Command
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/tests/Fixture/Message/FindTaskQuery.php
+++ b/tests/Fixture/Message/FindTaskQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Query;
+
+/**
+ * Query retrieving the name of a task by id.
+ */
+final class FindTaskQuery implements Query
+{
+    public function __construct(public readonly string $taskId)
+    {
+    }
+}

--- a/tests/Fixture/Message/GenerateReportCommand.php
+++ b/tests/Fixture/Message/GenerateReportCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Command;
+
+/**
+ * Command dispatched to the asynchronous command bus.
+ */
+final class GenerateReportCommand implements Command
+{
+    public function __construct(public readonly string $reportId)
+    {
+    }
+}

--- a/tests/Fixture/Message/TaskCreatedEvent.php
+++ b/tests/Fixture/Message/TaskCreatedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Event;
+
+/**
+ * Domain event emitted whenever a task has been created.
+ */
+final class TaskCreatedEvent implements Event
+{
+    public function __construct(public readonly string $taskId)
+    {
+    }
+}

--- a/tests/Fixture/Service/TaskRecorder.php
+++ b/tests/Fixture/Service/TaskRecorder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\Tests\Fixture\Service;
 
+use function in_array;
+
 /**
  * In-memory storage used by functional Messenger tests.
  */

--- a/tests/Fixture/Service/TaskRecorder.php
+++ b/tests/Fixture/Service/TaskRecorder.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Service;
+
+/**
+ * In-memory storage used by functional Messenger tests.
+ */
+final class TaskRecorder
+{
+    /** @var array<string, string> */
+    private array $tasks = [];
+
+    /** @var list<string> */
+    private array $asyncReports = [];
+
+    /** @var list<string> */
+    private array $events = [];
+
+    /** @var list<string> */
+    private array $asyncEvents = [];
+
+    public function reset(): void
+    {
+        $this->tasks = [];
+        $this->asyncReports = [];
+        $this->events = [];
+        $this->asyncEvents = [];
+    }
+
+    public function recordTask(string $id, string $name): void
+    {
+        $this->tasks[$id] = $name;
+    }
+
+    public function task(string $id): ?string
+    {
+        return $this->tasks[$id] ?? null;
+    }
+
+    public function recordReport(string $reportId): void
+    {
+        $this->asyncReports[] = $reportId;
+    }
+
+    public function hasReport(string $reportId): bool
+    {
+        return in_array($reportId, $this->asyncReports, true);
+    }
+
+    public function recordEvent(string $taskId): void
+    {
+        $this->events[] = $taskId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    public function recordAsyncEvent(string $taskId): void
+    {
+        $this->asyncEvents[] = $taskId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function asyncEvents(): array
+    {
+        return $this->asyncEvents;
+    }
+}

--- a/tests/Functional/MessengerIntegrationTest.php
+++ b/tests/Functional/MessengerIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Functional;
+
+use SomeWork\CqrsBundle\Bus\CommandBus;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Bus\EventBus;
+use SomeWork\CqrsBundle\Bus\QueryBus;
+use SomeWork\CqrsBundle\Tests\Fixture\Kernel\TestKernel;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\GenerateReportCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Service\TaskRecorder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class MessengerIntegrationTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        static::getContainer()->get(TaskRecorder::class)->reset();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function test_command_bus_dispatches_sync_command(): void
+    {
+        $commandBus = static::getContainer()->get(CommandBus::class);
+        $recorder = static::getContainer()->get(TaskRecorder::class);
+
+        $commandBus->dispatch(new CreateTaskCommand('task-1', 'Write docs'));
+
+        self::assertSame('Write docs', $recorder->task('task-1'));
+    }
+
+    public function test_command_bus_dispatches_async_command(): void
+    {
+        $commandBus = static::getContainer()->get(CommandBus::class);
+        $recorder = static::getContainer()->get(TaskRecorder::class);
+
+        $commandBus->dispatch(new GenerateReportCommand('report-1'), DispatchMode::ASYNC);
+
+        self::assertTrue($recorder->hasReport('report-1'));
+    }
+
+    public function test_event_bus_supports_sync_and_async_dispatch(): void
+    {
+        $eventBus = static::getContainer()->get(EventBus::class);
+        $recorder = static::getContainer()->get(TaskRecorder::class);
+
+        $eventBus->dispatch(new TaskCreatedEvent('sync-task'));
+        $eventBus->dispatch(new TaskCreatedEvent('async-task'), DispatchMode::ASYNC);
+
+        self::assertContains('sync-task', $recorder->events());
+        self::assertContains('async-task', $recorder->asyncEvents());
+    }
+
+    public function test_query_bus_returns_handler_result(): void
+    {
+        $commandBus = static::getContainer()->get(CommandBus::class);
+        $queryBus = static::getContainer()->get(QueryBus::class);
+
+        $commandBus->dispatch(new CreateTaskCommand('task-2', 'Review PR'));
+        $result = $queryBus->ask(new FindTaskQuery('task-2'));
+
+        self::assertSame('Review PR', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- document messenger and CQRS bundle configuration for prod, dev, and test environments
- expose CQRS bus services and allow configuring dedicated synchronous and asynchronous buses
- add a minimal kernel with messenger fixtures and functional tests covering sync and async dispatch

## Testing
- composer validate
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68da604610ac832084a4600186ecb1dc