### PR TITLE
Add CQRS tooling, autoconfiguration, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,90 @@
 # SomeWork CQRS Bundle
 
-The bundle builds on top of Symfony Messenger. Configure dedicated command, query, and event buses so the provided facades can route messages deterministically across environments.
+A set of CQRS helpers for Symfony Messenger. The bundle wires command, query,
+and event buses to Messenger, discovers handlers automatically, and ships with
+tooling that keeps your catalogue maintainable.
+
+## Features
+
+* PHP attributes (`#[AsCommandHandler]`, `#[AsQueryHandler]`, `#[AsEventHandler]`)
+  and marker interfaces that auto-tag handlers for Messenger.
+* Console tooling to list registered handlers and scaffold new messages.
+* Configuration hooks for naming strategies, retry policies, and serializer
+  stamps.
+* Plays nicely with multiple Messenger buses (sync and async).
+
+## Quick start
+
+```php
+<?php
+
+namespace App\Application\Command;
+
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Bus\CommandBus;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\CommandHandler;
+
+final class ShipOrder implements Command
+{
+    public function __construct(public readonly string $orderId) {}
+}
+
+#[AsCommandHandler(command: ShipOrder::class)]
+final class ShipOrderHandler implements CommandHandler
+{
+    public function __invoke(ShipOrder $command): mixed
+    {
+        // Dispatch domain logic here
+        return null;
+    }
+}
+```
+
+Inject `SomeWork\CqrsBundle\Bus\CommandBus` and call
+`$commandBus->dispatch(new ShipOrder($id));` to execute your handler.
+
+## Console commands
+
+* `bin/console somework:cqrs:list` – renders a table of commands, queries, and
+  events detected in the container. Filter by message type via
+  `--type=command|query|event`.
+* `bin/console somework:cqrs:generate command App\Application\Command\ShipOrder`
+  – generates a message and handler skeleton under your project `src/`
+  directory. Use `--dir=` to override the base directory and `--force` to
+  overwrite existing files.
+
+## Configuration
+
+All options live under the `somework_cqrs` key. They allow you to point each
+CQRS facade at specific Messenger buses, override naming strategies, and provide
+retry/serialization policies that append Messenger stamps.
+
+```yaml
+somework_cqrs:
+    default_bus: messenger.default_bus
+    buses:
+        command: messenger.bus.commands
+        command_async: messenger.bus.commands_async
+        query: messenger.bus.queries
+        event: messenger.bus.events
+        event_async: messenger.bus.events_async
+    naming:
+        default: SomeWork\CqrsBundle\Support\ClassNameMessageNamingStrategy
+    retry_policies:
+        command: SomeWork\CqrsBundle\Support\NullRetryPolicy
+    serialization:
+        command: SomeWork\CqrsBundle\Support\NullMessageSerializer
+```
+
+See [`docs/reference.md`](docs/reference.md) for a complete description of every
+option and [`docs/usage.md`](docs/usage.md) for more examples.
 
 ## Messenger configuration
+
+The bundle relies on standard Messenger buses. Configure them according to your
+environment (sync, async, transports) and wire the CQRS facades to the desired
+bus ids.
 
 ### Shared defaults (`config/packages/messenger.yaml`)
 
@@ -22,22 +104,10 @@ framework:
                     enabled: true
 ```
 
-### CQRS bundle defaults (`config/packages/somework_cqrs.yaml`)
-
-```yaml
-somework_cqrs:
-    default_bus: messenger.bus.commands
-    buses:
-        command: messenger.bus.commands
-        command_async: messenger.bus.commands_async
-        query: messenger.bus.queries
-        event: messenger.bus.events
-        event_async: messenger.bus.events_async
-```
-
 ### Production transport setup (`config/packages/prod/messenger.yaml`)
 
-Configure real transports and routing so asynchronous commands and events leave the HTTP process.
+Configure real transports and routing so asynchronous commands and events leave
+the HTTP process.
 
 ```yaml
 framework:
@@ -52,11 +122,13 @@ framework:
             'App\\Domain\\Event\\TaskCreated': async
 ```
 
-Run the worker with `bin/console messenger:consume async` to process queued messages.
+Run the worker with `bin/console messenger:consume async` to process queued
+messages.
 
 ### Development overrides (`config/packages/dev/messenger.yaml`)
 
-Point the async transport at a developer-friendly backend (for example Doctrine or Redis) and allow Messenger to create it on the fly:
+Point the async transport at a developer-friendly backend and allow Messenger to
+create it on the fly:
 
 ```yaml
 framework:
@@ -70,7 +142,8 @@ framework:
 
 ### Test overrides (`config/packages/test/messenger.yaml`)
 
-Use an in-memory transport so functional tests can assert on dispatched messages without spawning workers.
+Use an in-memory transport so functional tests can assert on dispatched messages
+without spawning workers.
 
 ```yaml
 framework:
@@ -82,4 +155,5 @@ framework:
             'App\\Domain\\Event\\TaskCreated': async
 ```
 
-With these settings the command, event, and query bus facades provided by the bundle transparently adapt to each environment.
+With these settings the command, event, and query bus facades provided by the
+bundle transparently adapt to each environment.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ Inject `SomeWork\CqrsBundle\Bus\CommandBus` and call
   directory. Use `--dir=` to override the base directory and `--force` to
   overwrite existing files.
 
+### Handler registry and diagnostics
+
+The bundle exposes a `SomeWork\CqrsBundle\Registry\HandlerRegistry` service that
+holds the metadata discovered at compile time. You can inject it to build custom
+dashboards, health checks, or documentation. The bundled `somework:cqrs:list`
+command uses the registry to produce a concise overview of your catalogue:
+
+```
+$ bin/console somework:cqrs:list
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+| Type    | Message                                    | Handler                                       | Service Id                                   | Bus                      |
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+| Command | App\Application\Command\ShipOrder          | App\Application\Command\ShipOrderHandler      | app.command.ship_order_handler               | messenger.bus.commands   |
+| Query   | App\ReadModel\Query\FindOrder              | App\ReadModel\Query\FindOrderHandler          | app.read_model.find_order_handler            | default                  |
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+```
+
+### Message scaffolding options
+
+The generator accepts a handful of options so you can tailor the output to your
+project layout:
+
+* `--handler=App\\Application\\Command\\ShipOrderHandler` – override the
+  handler class name instead of using the `<Message>Handler` default.
+* `--dir=app/src` – change the base directory used to materialise the class
+  files. The argument is relative to the project root returned by the kernel.
+* `--force` – replace existing files instead of halting with an error.
+
 ## Configuration
 
 All options live under the `somework_cqrs` key. They allow you to point each

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,48 @@
+# Configuration reference
+
+The bundle exposes the `somework_cqrs` configuration tree. Every option accepts
+a service id or fully-qualified class name. When you pass a class name the
+bundle will register it as an autowired, autoconfigured service automatically.
+
+```yaml
+# config/packages/somework_cqrs.yaml
+somework_cqrs:
+    default_bus: messenger.default_bus
+    buses:
+        command: messenger.bus.commands
+        command_async: messenger.bus.commands_async
+        query: messenger.bus.queries
+        event: messenger.bus.events
+        event_async: messenger.bus.events_async
+    naming:
+        default: SomeWork\CqrsBundle\Support\ClassNameMessageNamingStrategy
+        command: app.command_naming_strategy            # optional override
+        query: null                                     # falls back to default
+        event: null
+    retry_policies:
+        command: SomeWork\CqrsBundle\Support\NullRetryPolicy
+        query: app.query_retry_policy
+        event: SomeWork\CqrsBundle\Support\NullRetryPolicy
+    serialization:
+        command: SomeWork\CqrsBundle\Support\NullMessageSerializer
+        query: app.query_serializer
+        event: SomeWork\CqrsBundle\Support\NullMessageSerializer
+```
+
+* **default_bus** – fallback Messenger bus id. Used whenever a type-specific bus
+  is omitted.
+* **buses** – service ids for the synchronous and asynchronous Messenger buses
+  backing each CQRS facade.
+* **naming** – strategies implementing
+  `SomeWork\CqrsBundle\Contract\MessageNamingStrategy`. They control the human
+  readable message names exposed in CLI tooling and diagnostics.
+* **retry_policies** – services implementing
+  `SomeWork\CqrsBundle\Contract\RetryPolicy`. The buses merge the returned
+  stamps into each dispatch call so you can apply custom retry strategies per
+  message type.
+* **serialization** – services implementing
+  `SomeWork\CqrsBundle\Contract\MessageSerializer`. When the service returns a
+  `SerializerStamp` it is appended to the dispatch call.
+
+All options are optional. When you omit a setting the bundle falls back to a
+safe default implementation that leaves Messenger behaviour unchanged.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,3 +46,32 @@ somework_cqrs:
 
 All options are optional. When you omit a setting the bundle falls back to a
 safe default implementation that leaves Messenger behaviour unchanged.
+
+## Handler registry service
+
+The bundle stores compiled handler metadata in the
+`SomeWork\CqrsBundle\Registry\HandlerRegistry` service. You can rely on it to
+power diagnostics, smoke tests, or documentation pages. The registry exposes:
+
+* `all()` – returns every handler as a list of `HandlerDescriptor` value
+  objects.
+* `byType('command'|'query'|'event')` – limits the descriptors to one message
+  type.
+* `getDisplayName(HandlerDescriptor)` – resolves a human-friendly name using the
+  configured naming strategies.
+
+## Console reference
+
+Two console commands ship with the bundle:
+
+* `somework:cqrs:list` – Prints the handler catalogue in a table. Accepts the
+  `--type=<command|query|event>` option multiple times. The command is safe to
+  run in production and reflects the container compiled for the current
+  environment.
+* `somework:cqrs:generate <type> <class>` – Scaffolds a message and handler pair
+  for the chosen type. Optional flags:
+  * `--handler=` to customise the handler class name.
+  * `--dir=` to override the base directory (defaults to `<project>/src`).
+  * `--force` to overwrite existing files instead of aborting.
+
+Both commands are registered automatically when the bundle is enabled.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,87 @@
+# Usage guide
+
+This bundle layers a CQRS-friendly API on top of Symfony Messenger. It provides
+attribute-based autoconfiguration, optional interfaces, and tooling to keep your
+handler catalogue discoverable.
+
+## Registering handlers with attributes
+
+Annotate handlers with the provided attributes to automatically add the correct
+`messenger.message_handler` tags. The bundle will infer the bus from your
+configuration when the `bus` argument is omitted.
+
+```php
+<?php
+
+namespace App\Application\Command;
+
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\CommandHandler;
+
+final class ApproveInvoice implements Command
+{
+    public function __construct(
+        public readonly string $invoiceId,
+    ) {
+    }
+}
+
+#[AsCommandHandler(command: ApproveInvoice::class)]
+final class ApproveInvoiceHandler implements CommandHandler
+{
+    public function __invoke(ApproveInvoice $command): mixed
+    {
+        // Handle the command…
+        return null;
+    }
+}
+```
+
+The same pattern exists for queries (`#[AsQueryHandler]`) and events
+(`#[AsEventHandler]`).
+
+## Interface autoconfiguration
+
+If you prefer interfaces over attributes the bundle can still discover your
+handlers. Implement one of the marker interfaces and type-hint the message on
+`__invoke()`. The compiler pass inspects the argument type to figure out which
+message the handler is responsible for.
+
+```php
+<?php
+
+namespace App\ReadModel;
+
+use App\Domain\Event\InvoicePaid;
+use SomeWork\CqrsBundle\Contract\EventHandler;
+
+final class InvoicePaidProjector implements EventHandler
+{
+    public function __invoke(InvoicePaid $event): void
+    {
+        // Persist read model changes here.
+    }
+}
+```
+
+## Console tooling
+
+Two commands ship with the bundle once it is registered in your kernel:
+
+* `somework:cqrs:list` renders a table of discovered messages and their
+  handlers. Use `--type=command` (or `query` / `event`) to focus the output.
+* `somework:cqrs:generate` scaffolds a message class and handler skeleton. Run
+  `bin/console somework:cqrs:generate command App\Application\Command\ShipOrder`
+  to produce `ShipOrder` and `ShipOrderHandler` inside your project `src/`
+  directory. Pass `--dir=app/src` and `--force` to customise the target or
+  overwrite existing files.
+
+These commands respect the naming strategy configured for the bundle when
+presenting handler information.
+
+## Messenger integration
+
+The bundle does not replace Messenger configuration. Configure your buses and
+transports as usual and wire the CQRS buses to the appropriate Messenger buses.
+See the reference documentation for the list of configurable options.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,6 +77,35 @@ Two commands ship with the bundle once it is registered in your kernel:
   directory. Pass `--dir=app/src` and `--force` to customise the target or
   overwrite existing files.
 
+Example output from `somework:cqrs:list`:
+
+```
+$ bin/console somework:cqrs:list --type=command --type=query
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+| Type    | Message                                    | Handler                                       | Service Id                                   | Bus                      |
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+| Command | App\Application\Command\ShipOrder          | App\Application\Command\ShipOrderHandler      | app.command.ship_order_handler               | messenger.bus.commands   |
+| Query   | App\ReadModel\Query\FindOrder              | App\ReadModel\Query\FindOrderHandler          | app.read_model.find_order_handler            | default                  |
++---------+--------------------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------+
+```
+
+The command respects naming strategies registered for each message type so the
+display names stay meaningful even when your classes follow domain-specific
+conventions.
+
+For the generator you can pass the following options to tailor the output:
+
+* `--handler` – override the handler class name. The command still generates the
+  attribute and interface wiring for you.
+* `--dir` – write the files to a custom base directory. Useful when your source
+  tree lives outside the default `src/` folder.
+* `--force` – overwrite existing files instead of aborting. Handy when you want
+  to regenerate boilerplate after renaming namespaces.
+
+Inject `SomeWork\CqrsBundle\Registry\HandlerRegistry` if you need direct access
+to the metadata powering the CLI. It offers `all()`, `byType()`, and
+`getDisplayName()` helpers that you can reuse in dashboards or smoke tests.
+
 These commands respect the naming strategy configured for the bundle when
 presenting handler information.
 

--- a/src/Bus/CommandBus.php
+++ b/src/Bus/CommandBus.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SomeWork\CqrsBundle\Bus;
 
 use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\MessageSerializer;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
@@ -17,6 +19,8 @@ final class CommandBus
     public function __construct(
         private readonly MessageBusInterface $syncBus,
         private readonly ?MessageBusInterface $asyncBus = null,
+        private readonly RetryPolicy $retryPolicy = new \SomeWork\CqrsBundle\Support\NullRetryPolicy(),
+        private readonly MessageSerializer $serializer = new \SomeWork\CqrsBundle\Support\NullMessageSerializer(),
     ) {
     }
 
@@ -25,6 +29,13 @@ final class CommandBus
      */
     public function dispatch(Command $command, DispatchMode $mode = DispatchMode::SYNC, StampInterface ...$stamps): Envelope
     {
+        $stamps = [...$stamps, ...$this->retryPolicy->getStamps($command, $mode)];
+
+        $serializerStamp = $this->serializer->getStamp($command, $mode);
+        if (null !== $serializerStamp) {
+            $stamps[] = $serializerStamp;
+        }
+
         return $this->selectBus($mode)->dispatch($command, $stamps);
     }
 

--- a/src/Bus/EventBus.php
+++ b/src/Bus/EventBus.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SomeWork\CqrsBundle\Bus;
 
 use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Contract\MessageSerializer;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
@@ -17,6 +19,8 @@ final class EventBus
     public function __construct(
         private readonly MessageBusInterface $syncBus,
         private readonly ?MessageBusInterface $asyncBus = null,
+        private readonly RetryPolicy $retryPolicy = new \SomeWork\CqrsBundle\Support\NullRetryPolicy(),
+        private readonly MessageSerializer $serializer = new \SomeWork\CqrsBundle\Support\NullMessageSerializer(),
     ) {
     }
 
@@ -25,6 +29,13 @@ final class EventBus
      */
     public function dispatch(Event $event, DispatchMode $mode = DispatchMode::SYNC, StampInterface ...$stamps): Envelope
     {
+        $stamps = [...$stamps, ...$this->retryPolicy->getStamps($event, $mode)];
+
+        $serializerStamp = $this->serializer->getStamp($event, $mode);
+        if (null !== $serializerStamp) {
+            $stamps[] = $serializerStamp;
+        }
+
         return $this->selectBus($mode)->dispatch($event, $stamps);
     }
 

--- a/src/Bus/QueryBus.php
+++ b/src/Bus/QueryBus.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\Bus;
 
-use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Contract\MessageSerializer;
 use SomeWork\CqrsBundle\Contract\Query;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;

--- a/src/Command/GenerateMessageCommand.php
+++ b/src/Command/GenerateMessageCommand.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Command;
+
+use RuntimeException;
+use SomeWork\CqrsBundle\Attribute\AsCommandHandler;
+use SomeWork\CqrsBundle\Attribute\AsEventHandler;
+use SomeWork\CqrsBundle\Attribute\AsQueryHandler;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\CommandHandler;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Contract\EventHandler;
+use SomeWork\CqrsBundle\Contract\Query;
+use SomeWork\CqrsBundle\Contract\QueryHandler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[AsCommand(
+    name: 'somework:cqrs:generate',
+    description: 'Generate a CQRS message and handler skeleton.',
+)]
+final class GenerateMessageCommand extends SymfonyCommand
+{
+    /** @var array<string, class-string> */
+    private const MESSAGE_INTERFACES = [
+        'command' => Command::class,
+        'query' => Query::class,
+        'event' => Event::class,
+    ];
+
+    /** @var array<string, class-string> */
+    private const HANDLER_INTERFACES = [
+        'command' => CommandHandler::class,
+        'query' => QueryHandler::class,
+        'event' => EventHandler::class,
+    ];
+
+    /** @var array<string, class-string> */
+    private const HANDLER_ATTRIBUTES = [
+        'command' => AsCommandHandler::class,
+        'query' => AsQueryHandler::class,
+        'event' => AsEventHandler::class,
+    ];
+
+    public function __construct(private readonly KernelInterface $kernel)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('type', InputArgument::REQUIRED, 'Message type (command, query, event).')
+            ->addArgument('name', InputArgument::REQUIRED, 'Fully-qualified class name of the message.')
+            ->addOption('handler', null, InputOption::VALUE_OPTIONAL, 'Fully-qualified class name of the handler. Defaults to <MessageName>Handler.')
+            ->addOption('dir', null, InputOption::VALUE_REQUIRED, 'Base directory where classes should be generated. Defaults to <project>/src.')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Overwrite files if they already exist.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $type = strtolower((string) $input->getArgument('type'));
+        if (!isset(self::MESSAGE_INTERFACES[$type])) {
+            $io->error('Supported types are: command, query, event.');
+
+            return self::FAILURE;
+        }
+
+        $messageClass = (string) $input->getArgument('name');
+        $handlerClass = (string) ($input->getOption('handler') ?: $messageClass.'Handler');
+        $baseDir = (string) ($input->getOption('dir') ?: $this->kernel->getProjectDir().'/src');
+        $force = (bool) $input->getOption('force');
+
+        [$messageNamespace, $messageShortClass] = $this->splitClass($messageClass);
+        [$handlerNamespace, $handlerShortClass] = $this->splitClass($handlerClass);
+
+        $messagePath = $this->classToPath($baseDir, $messageClass);
+        $handlerPath = $this->classToPath($baseDir, $handlerClass);
+
+        try {
+            $this->dumpFile($messagePath, $this->generateMessage($type, $messageNamespace, $messageShortClass), $force);
+            $this->dumpFile($handlerPath, $this->generateHandler($type, $messageClass, $handlerNamespace, $handlerShortClass), $force);
+        } catch (RuntimeException $exception) {
+            $io->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $io->success(sprintf('Generated %s and %s.', $this->relativePath($messagePath), $this->relativePath($handlerPath)));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitClass(string $class): array
+    {
+        $parts = explode('\\', $class);
+        $short = array_pop($parts);
+        $namespace = implode('\\', $parts);
+
+        return [$namespace, $short ?? $class];
+    }
+
+    private function classToPath(string $baseDir, string $class): string
+    {
+        $baseDir = rtrim($baseDir, '/');
+
+        return $baseDir.'/'.str_replace('\\', '/', $class).'.php';
+    }
+
+    private function dumpFile(string $path, string $contents, bool $force): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        if (!$force && file_exists($path)) {
+            throw new RuntimeException(sprintf('File "%s" already exists. Use --force to overwrite.', $path));
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function generateMessage(string $type, string $namespace, string $class): string
+    {
+        $interface = self::MESSAGE_INTERFACES[$type];
+        $shortInterface = basename(str_replace('\\', '/', $interface));
+
+        $lines = [
+            '<?php',
+            '',
+            'declare(strict_types=1);',
+            '',
+            sprintf('namespace %s;', $namespace ?: 'App'),
+            '',
+            sprintf('use %s;', $interface),
+            '',
+            sprintf('final class %s implements %s', $class, $shortInterface),
+            '{',
+            '    public function __construct()',
+            '    {',
+            '    }',
+            '}',
+            '',
+        ];
+
+        return implode("\n", $lines);
+    }
+
+    private function generateHandler(string $type, string $messageClass, string $namespace, string $class): string
+    {
+        $interface = self::HANDLER_INTERFACES[$type];
+        $attribute = self::HANDLER_ATTRIBUTES[$type];
+        $shortInterface = basename(str_replace('\\', '/', $interface));
+        $shortAttribute = basename(str_replace('\\', '/', $attribute));
+        $shortMessage = basename(str_replace('\\', '/', $messageClass));
+
+        $methodSignature = sprintf('    public function __invoke(%s $message): mixed', $shortMessage);
+        $methodBody = [
+            '        // TODO: Implement handler logic.',
+            '',
+            '        return null;',
+        ];
+
+        if ('query' === $type) {
+            $methodBody = [
+                '        // TODO: Return the query result.',
+                '',
+                '        return null;',
+            ];
+        }
+
+        if ('event' === $type) {
+            $methodSignature = sprintf('    public function __invoke(%s $message): void', $shortMessage);
+            $methodBody = [
+                '        // TODO: React to the event.',
+            ];
+        }
+
+        $lines = [
+            '<?php',
+            '',
+            'declare(strict_types=1);',
+            '',
+            sprintf('namespace %s;', $namespace ?: 'App'),
+            '',
+            sprintf('use %s;', $attribute),
+            sprintf('use %s;', $interface),
+            sprintf('use %s;', $messageClass),
+            '',
+            sprintf('#[%s(%s::class)]', $shortAttribute, $shortMessage),
+            sprintf('final class %s implements %s', $class, $shortInterface),
+            '{',
+            $methodSignature,
+            '    {',
+        ];
+
+        $lines = array_merge($lines, $methodBody);
+
+        $lines[] = '    }';
+        $lines[] = '}';
+        $lines[] = '';
+
+        return implode("\n", $lines);
+    }
+
+    private function relativePath(string $path): string
+    {
+        $projectDir = rtrim($this->kernel->getProjectDir(), '/');
+        $normalised = str_replace('\\', '/', $path);
+
+        if (str_starts_with($normalised, $projectDir.'/')) {
+            return substr($normalised, strlen($projectDir) + 1);
+        }
+
+        return $normalised;
+    }
+}

--- a/src/Command/GenerateMessageCommand.php
+++ b/src/Command/GenerateMessageCommand.php
@@ -23,6 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+use function dirname;
+use function sprintf;
+use function strlen;
+
 #[AsCommand(
     name: 'somework:cqrs:generate',
     description: 'Generate a CQRS message and handler skeleton.',
@@ -122,9 +126,9 @@ final class GenerateMessageCommand extends SymfonyCommand
 
     private function dumpFile(string $path, string $contents, bool $force): void
     {
-        $dir = \dirname($path);
+        $dir = dirname($path);
         if (!is_dir($dir)) {
-            mkdir($dir, 0775, true);
+            mkdir($dir, 0o775, true);
         }
 
         if (!$force && file_exists($path)) {

--- a/src/Command/ListHandlersCommand.php
+++ b/src/Command/ListHandlersCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Command;
+
+use SomeWork\CqrsBundle\Registry\HandlerDescriptor;
+use SomeWork\CqrsBundle\Registry\HandlerRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'somework:cqrs:list',
+    description: 'List CQRS commands, queries, and events registered in Messenger.',
+)]
+final class ListHandlersCommand extends Command
+{
+    public function __construct(private readonly HandlerRegistry $registry)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('type', mode: InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, description: 'Filter by message type (command, query, event).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var array<int, string>|string|null $requestedTypes */
+        $requestedTypes = $input->getOption('type');
+        $types = $this->normaliseTypes($requestedTypes);
+
+        $rows = [];
+        foreach ($types as $type) {
+            $descriptors = $this->registry->byType($type);
+            foreach ($descriptors as $descriptor) {
+                $rows[] = $this->formatDescriptor($descriptor);
+            }
+        }
+
+        if ([] === $rows) {
+            $io->warning('No CQRS handlers were found for the given filters.');
+
+            return self::SUCCESS;
+        }
+
+        usort(
+            $rows,
+            static fn (array $a, array $b): int => [$a[0], $a[1]] <=> [$b[0], $b[1]]
+        );
+
+        $table = new Table($output);
+        $table->setHeaders(['Type', 'Message', 'Handler', 'Service Id', 'Bus']);
+        $table->setRows($rows);
+        $table->render();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<int, string>|string|null $requested
+     *
+     * @return list<'command'|'query'|'event'>
+     */
+    private function normaliseTypes(array|string|null $requested): array
+    {
+        $available = ['command', 'query', 'event'];
+
+        if (null === $requested || [] === $requested) {
+            return $available;
+        }
+
+        if (is_string($requested)) {
+            $requested = [$requested];
+        }
+
+        $types = [];
+        foreach ($requested as $type) {
+            $type = strtolower($type);
+            if (in_array($type, $available, true)) {
+                $types[] = $type;
+            }
+        }
+
+        return array_values(array_unique($types));
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string, 3: string, 4: string}
+     */
+    private function formatDescriptor(HandlerDescriptor $descriptor): array
+    {
+        return [
+            ucfirst($descriptor->type),
+            $this->registry->getDisplayName($descriptor),
+            $descriptor->handlerClass,
+            $descriptor->serviceId,
+            $descriptor->bus ?? 'default',
+        ];
+    }
+}

--- a/src/Command/ListHandlersCommand.php
+++ b/src/Command/ListHandlersCommand.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function in_array;
+use function is_string;
+
 #[AsCommand(
     name: 'somework:cqrs:list',
     description: 'List CQRS commands, queries, and events registered in Messenger.',

--- a/src/Contract/MessageNamingStrategy.php
+++ b/src/Contract/MessageNamingStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+/**
+ * Resolves display names for CQRS messages.
+ */
+interface MessageNamingStrategy
+{
+    /**
+     * @param class-string $messageClass
+     */
+    public function getName(string $messageClass): string;
+}

--- a/src/Contract/MessageSerializer.php
+++ b/src/Contract/MessageSerializer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use Symfony\Component\Messenger\Stamp\SerializerStamp;
+
+/**
+ * Supplies serializer stamps applied when dispatching CQRS messages.
+ */
+interface MessageSerializer
+{
+    public function getStamp(object $message, DispatchMode $mode): ?SerializerStamp;
+}

--- a/src/Contract/RetryPolicy.php
+++ b/src/Contract/RetryPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Provides messenger stamps that control retry behaviour when dispatching messages.
+ */
+interface RetryPolicy
+{
+    /**
+     * @return list<StampInterface>
+     */
+    public function getStamps(object $message, DispatchMode $mode): array;
+}

--- a/src/DependencyInjection/Compiler/CqrsHandlerPass.php
+++ b/src/DependencyInjection/Compiler/CqrsHandlerPass.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+use function is_string;
+
 final class CqrsHandlerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/DependencyInjection/Compiler/CqrsHandlerPass.php
+++ b/src/DependencyInjection/Compiler/CqrsHandlerPass.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\DependencyInjection\Compiler;
+
+use ReflectionClass;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Contract\Query;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final class CqrsHandlerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('somework_cqrs.handler_metadata')) {
+            $container->setParameter('somework_cqrs.handler_metadata', []);
+        }
+
+        $parameterBag = $container->getParameterBag();
+        $metadata = [
+            'command' => [],
+            'query' => [],
+            'event' => [],
+        ];
+
+        foreach ($container->findTaggedServiceIds('somework_cqrs.handler_interface') as $serviceId => $tags) {
+            $definition = $container->getDefinition($serviceId);
+
+            if (!$definition->hasTag('messenger.message_handler')) {
+                foreach ($tags as $attributes) {
+                    $definition->addTag(
+                        'messenger.message_handler',
+                        array_filter([
+                            'bus' => $attributes['bus'] ?? null,
+                            'method' => $attributes['method'] ?? '__invoke',
+                        ], static fn ($value): bool => null !== $value)
+                    );
+                }
+            }
+
+            $definition->clearTag('somework_cqrs.handler_interface');
+        }
+
+        foreach ($container->findTaggedServiceIds('messenger.message_handler') as $serviceId => $tags) {
+            $definition = $container->findDefinition($serviceId);
+            $handlerClass = $this->resolveClassName($definition, $parameterBag);
+
+            if (null === $handlerClass) {
+                continue;
+            }
+
+            foreach ($tags as $attributes) {
+                $messageClass = $this->resolveMessageClass($handlerClass, $attributes);
+                if (null === $messageClass) {
+                    continue;
+                }
+
+                $type = $this->determineType($messageClass);
+                if (null === $type) {
+                    continue;
+                }
+
+                $metadata[$type][] = [
+                    'type' => $type,
+                    'message' => $messageClass,
+                    'handler_class' => $handlerClass,
+                    'service_id' => $serviceId,
+                    'bus' => $attributes['bus'] ?? null,
+                ];
+            }
+        }
+
+        $container->setParameter('somework_cqrs.handler_metadata', $metadata);
+    }
+
+    private function resolveClassName(Definition $definition, ParameterBagInterface $parameterBag): ?string
+    {
+        $class = $definition->getClass();
+        if (null === $class) {
+            if ($definition instanceof ChildDefinition) {
+                $class = $definition->getClass();
+            }
+        }
+
+        if (null === $class) {
+            return null;
+        }
+
+        $class = $parameterBag->resolveValue($class);
+
+        return is_string($class) ? $class : null;
+    }
+
+    /**
+     * @param array{handles?: class-string, method?: string} $attributes
+     */
+    private function resolveMessageClass(string $handlerClass, array $attributes): ?string
+    {
+        if (isset($attributes['handles']) && is_string($attributes['handles'])) {
+            return $attributes['handles'];
+        }
+
+        $reflection = new ReflectionClass($handlerClass);
+        if (!$reflection->hasMethod('__invoke')) {
+            return null;
+        }
+
+        $method = $reflection->getMethod('__invoke');
+        $parameters = $method->getParameters();
+        if ([] === $parameters) {
+            return null;
+        }
+
+        $type = $parameters[0]->getType();
+        if (null === $type || $type->isBuiltin()) {
+            return null;
+        }
+
+        $name = $type->getName();
+        if (class_exists($name) || interface_exists($name)) {
+            return $name;
+        }
+
+        return null;
+    }
+
+    private function determineType(string $messageClass): ?string
+    {
+        if (is_subclass_of($messageClass, Command::class)) {
+            return 'command';
+        }
+
+        if (is_subclass_of($messageClass, Query::class)) {
+            return 'query';
+        }
+
+        if (is_subclass_of($messageClass, Event::class)) {
+            return 'event';
+        }
+
+        return null;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\DependencyInjection;
 
+use SomeWork\CqrsBundle\Support\ClassNameMessageNamingStrategy;
+use SomeWork\CqrsBundle\Support\NullMessageSerializer;
+use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -72,6 +75,76 @@ final class Configuration implements ConfigurationInterface
 
         $busesChildren->end();
         $buses->end();
+
+        $naming = $children->arrayNode('naming');
+        $naming
+            ->addDefaultsIfNotSet()
+            ->info('Message naming strategies used by diagnostics and tooling.');
+
+        /** @var ArrayNodeDefinition $namingChildren */
+        $namingChildren = $naming->children();
+        $namingChildren
+            ->scalarNode('default')
+            ->defaultValue(ClassNameMessageNamingStrategy::class)
+            ->info('Service id implementing MessageNamingStrategy for all message types.');
+        $namingChildren
+            ->scalarNode('command')
+            ->defaultNull()
+            ->info('Overrides the default naming strategy for commands.');
+        $namingChildren
+            ->scalarNode('query')
+            ->defaultNull()
+            ->info('Overrides the default naming strategy for queries.');
+        $namingChildren
+            ->scalarNode('event')
+            ->defaultNull()
+            ->info('Overrides the default naming strategy for events.');
+        $namingChildren->end();
+        $naming->end();
+
+        $retry = $children->arrayNode('retry_policies');
+        $retry
+            ->addDefaultsIfNotSet()
+            ->info('Retry policy services applied when dispatching messages.');
+
+        /** @var ArrayNodeDefinition $retryChildren */
+        $retryChildren = $retry->children();
+        $retryChildren
+            ->scalarNode('command')
+            ->defaultValue(NullRetryPolicy::class)
+            ->info('RetryPolicy service id applied to commands.');
+        $retryChildren
+            ->scalarNode('event')
+            ->defaultValue(NullRetryPolicy::class)
+            ->info('RetryPolicy service id applied to events.');
+        $retryChildren
+            ->scalarNode('query')
+            ->defaultValue(NullRetryPolicy::class)
+            ->info('RetryPolicy service id applied to queries.');
+        $retryChildren->end();
+        $retry->end();
+
+        $serialization = $children->arrayNode('serialization');
+        $serialization
+            ->addDefaultsIfNotSet()
+            ->info('MessageSerializer services that provide SerializerStamp instances.');
+
+        /** @var ArrayNodeDefinition $serializationChildren */
+        $serializationChildren = $serialization->children();
+        $serializationChildren
+            ->scalarNode('command')
+            ->defaultValue(NullMessageSerializer::class)
+            ->info('MessageSerializer service id applied to commands.');
+        $serializationChildren
+            ->scalarNode('event')
+            ->defaultValue(NullMessageSerializer::class)
+            ->info('MessageSerializer service id applied to events.');
+        $serializationChildren
+            ->scalarNode('query')
+            ->defaultValue(NullMessageSerializer::class)
+            ->info('MessageSerializer service id applied to queries.');
+        $serializationChildren->end();
+        $serialization->end();
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -10,13 +10,19 @@ use SomeWork\CqrsBundle\Attribute\AsQueryHandler;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\EventBus;
 use SomeWork\CqrsBundle\Bus\QueryBus;
+use SomeWork\CqrsBundle\Contract\CommandHandler;
+use SomeWork\CqrsBundle\Contract\EventHandler;
+use SomeWork\CqrsBundle\Contract\QueryHandler;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
 
 final class CqrsExtension extends Extension
 {
@@ -30,11 +36,15 @@ final class CqrsExtension extends Extension
 
         $defaultBusId = $config['default_bus'] ?? 'messenger.default_bus';
         $container->setParameter('somework_cqrs.default_bus', $defaultBusId);
+        $container->setParameter('somework_cqrs.handler_metadata', []);
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
 
-        $this->registerHandlerAttributes($container);
+        $this->registerHandlerAutoconfiguration($container, $config['buses'], $defaultBusId);
+        $this->registerNamingStrategies($container, $config['naming']);
+        $this->registerRetryPolicies($container, $config['retry_policies']);
+        $this->registerSerializers($container, $config['serialization']);
         $this->configureBusServices($container, $config['buses'], $defaultBusId);
     }
 
@@ -64,11 +74,16 @@ final class CqrsExtension extends Extension
             } else {
                 $commandBusDefinition->setArgument('$asyncBus', null);
             }
+
+            $commandBusDefinition->setArgument('$retryPolicy', new Reference('somework_cqrs.retry.command'));
+            $commandBusDefinition->setArgument('$serializer', new Reference('somework_cqrs.serializer.command'));
         }
 
         if ($container->hasDefinition(QueryBus::class)) {
             $queryBusDefinition = $container->getDefinition(QueryBus::class);
             $queryBusDefinition->setArgument('$bus', new Reference($buses['query'] ?? $defaultBusId));
+            $queryBusDefinition->setArgument('$retryPolicy', new Reference('somework_cqrs.retry.query'));
+            $queryBusDefinition->setArgument('$serializer', new Reference('somework_cqrs.serializer.query'));
         }
 
         if ($container->hasDefinition(EventBus::class)) {
@@ -81,19 +96,30 @@ final class CqrsExtension extends Extension
             } else {
                 $eventBusDefinition->setArgument('$asyncBus', null);
             }
+
+            $eventBusDefinition->setArgument('$retryPolicy', new Reference('somework_cqrs.retry.event'));
+            $eventBusDefinition->setArgument('$serializer', new Reference('somework_cqrs.serializer.event'));
         }
     }
 
-    private function registerHandlerAttributes(ContainerBuilder $container): void
+    /**
+     * @param array<string, string|null> $buses
+     */
+    private function registerHandlerAutoconfiguration(ContainerBuilder $container, array $buses, string $defaultBusId): void
     {
+        $commandBusId = $buses['command'] ?? $defaultBusId;
+        $queryBusId = $buses['query'] ?? $defaultBusId;
+        $eventBusId = $buses['event'] ?? $defaultBusId;
+
         $container->registerAttributeForAutoconfiguration(
             AsCommandHandler::class,
-            static function (ChildDefinition $definition, AsCommandHandler $attribute): void {
+            static function (ChildDefinition $definition, AsCommandHandler $attribute) use ($commandBusId): void {
+                $bus = $attribute->bus ?? $commandBusId;
                 $definition->addTag(
                     'messenger.message_handler',
                     array_filter([
                         'handles' => $attribute->command,
-                        'bus' => $attribute->bus,
+                        'bus' => $bus,
                     ], static fn ($value): bool => null !== $value)
                 );
             }
@@ -101,12 +127,13 @@ final class CqrsExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(
             AsQueryHandler::class,
-            static function (ChildDefinition $definition, AsQueryHandler $attribute): void {
+            static function (ChildDefinition $definition, AsQueryHandler $attribute) use ($queryBusId): void {
+                $bus = $attribute->bus ?? $queryBusId;
                 $definition->addTag(
                     'messenger.message_handler',
                     array_filter([
                         'handles' => $attribute->query,
-                        'bus' => $attribute->bus,
+                        'bus' => $bus,
                     ], static fn ($value): bool => null !== $value)
                 );
             }
@@ -114,15 +141,93 @@ final class CqrsExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(
             AsEventHandler::class,
-            static function (ChildDefinition $definition, AsEventHandler $attribute): void {
+            static function (ChildDefinition $definition, AsEventHandler $attribute) use ($eventBusId): void {
+                $bus = $attribute->bus ?? $eventBusId;
                 $definition->addTag(
                     'messenger.message_handler',
                     array_filter([
                         'handles' => $attribute->event,
-                        'bus' => $attribute->bus,
+                        'bus' => $bus,
                     ], static fn ($value): bool => null !== $value)
                 );
             }
         );
+
+        $this->registerHandlerInterfaceAutoconfiguration($container, CommandHandler::class, $commandBusId, 'command');
+        $this->registerHandlerInterfaceAutoconfiguration($container, QueryHandler::class, $queryBusId, 'query');
+        $this->registerHandlerInterfaceAutoconfiguration($container, EventHandler::class, $eventBusId, 'event');
+    }
+
+    private function registerHandlerInterfaceAutoconfiguration(ContainerBuilder $container, string $interface, ?string $busId, string $type): void
+    {
+        $container->registerForAutoconfiguration($interface)
+            ->addTag(
+                'somework_cqrs.handler_interface',
+                array_filter([
+                    'bus' => $busId,
+                    'method' => '__invoke',
+                    'type' => $type,
+                ], static fn ($value): bool => null !== $value)
+            );
+    }
+
+    /**
+     * @param array{default: string, command?: string|null, query?: string|null, event?: string|null} $config
+     */
+    private function registerNamingStrategies(ContainerBuilder $container, array $config): void
+    {
+        $defaultId = $this->ensureServiceExists($container, $config['default']);
+        $commandId = $this->ensureServiceExists($container, $config['command'] ?? $defaultId);
+        $queryId = $this->ensureServiceExists($container, $config['query'] ?? $defaultId);
+        $eventId = $this->ensureServiceExists($container, $config['event'] ?? $defaultId);
+
+        $serviceMap = [
+            'default' => new ServiceClosureArgument(new Reference($defaultId)),
+            'command' => new ServiceClosureArgument(new Reference($commandId)),
+            'query' => new ServiceClosureArgument(new Reference($queryId)),
+            'event' => new ServiceClosureArgument(new Reference($eventId)),
+        ];
+
+        $locatorId = ServiceLocatorTagPass::register($container, $serviceMap);
+        $container->setAlias('somework_cqrs.naming_locator', (string) $locatorId)->setPublic(false);
+    }
+
+    /**
+     * @param array{command: string, query: string, event: string} $config
+     */
+    private function registerRetryPolicies(ContainerBuilder $container, array $config): void
+    {
+        $this->registerServiceAlias($container, 'somework_cqrs.retry.command', $config['command']);
+        $this->registerServiceAlias($container, 'somework_cqrs.retry.query', $config['query']);
+        $this->registerServiceAlias($container, 'somework_cqrs.retry.event', $config['event']);
+    }
+
+    /**
+     * @param array{command: string, query: string, event: string} $config
+     */
+    private function registerSerializers(ContainerBuilder $container, array $config): void
+    {
+        $this->registerServiceAlias($container, 'somework_cqrs.serializer.command', $config['command']);
+        $this->registerServiceAlias($container, 'somework_cqrs.serializer.query', $config['query']);
+        $this->registerServiceAlias($container, 'somework_cqrs.serializer.event', $config['event']);
+    }
+
+    private function registerServiceAlias(ContainerBuilder $container, string $aliasId, string $serviceId): void
+    {
+        $serviceId = $this->ensureServiceExists($container, $serviceId);
+
+        $container->setAlias($aliasId, $serviceId)->setPublic(false);
+    }
+
+    private function ensureServiceExists(ContainerBuilder $container, string $serviceId): string
+    {
+        if (!$container->has($serviceId) && class_exists($serviceId)) {
+            $definition = new Definition($serviceId);
+            $definition->setAutowired(true);
+            $definition->setAutoconfigured(true);
+            $container->setDefinition($serviceId, $definition);
+        }
+
+        return $serviceId;
     }
 }

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -19,10 +19,10 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
 
 final class CqrsExtension extends Extension
 {

--- a/src/Registry/HandlerDescriptor.php
+++ b/src/Registry/HandlerDescriptor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Registry;
+
+/**
+ * @internal
+ */
+final class HandlerDescriptor
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly string $messageClass,
+        public readonly string $handlerClass,
+        public readonly string $serviceId,
+        public readonly ?string $bus,
+    ) {
+    }
+}

--- a/src/Registry/HandlerRegistry.php
+++ b/src/Registry/HandlerRegistry.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Registry;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Provides read access to the CQRS handler map that is compiled at container build time.
+ */
+final class HandlerRegistry
+{
+    /**
+     * @param array<string, list<array{type: string, message: class-string, handler_class: class-string, service_id: string, bus: string|null}>> $metadata
+     */
+    public function __construct(
+        #[Autowire(param: 'somework_cqrs.handler_metadata')]
+        private readonly array $metadata,
+        #[Autowire(service: 'somework_cqrs.naming_locator')]
+        private readonly ContainerInterface $namingStrategies,
+    ) {
+    }
+
+    /**
+     * @return list<HandlerDescriptor>
+     */
+    public function all(): array
+    {
+        $descriptors = [];
+        foreach ($this->metadata as $type => $entries) {
+            foreach ($entries as $entry) {
+                $descriptors[] = $this->createDescriptor($type, $entry);
+            }
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * @return list<HandlerDescriptor>
+     */
+    public function byType(string $type): array
+    {
+        $entries = $this->metadata[$type] ?? [];
+        $descriptors = [];
+        foreach ($entries as $entry) {
+            $descriptors[] = $this->createDescriptor($type, $entry);
+        }
+
+        return $descriptors;
+    }
+
+    private function createDescriptor(string $type, array $entry): HandlerDescriptor
+    {
+        return new HandlerDescriptor(
+            $type,
+            $entry['message'],
+            $entry['handler_class'],
+            $entry['service_id'],
+            $entry['bus'],
+        );
+    }
+
+    public function getDisplayName(HandlerDescriptor $descriptor): string
+    {
+        $strategy = $this->namingStrategies->has($descriptor->type)
+            ? $this->namingStrategies->get($descriptor->type)
+            : $this->namingStrategies->get('default');
+
+        return $strategy->getName($descriptor->messageClass);
+    }
+}

--- a/src/SomeWorkCqrsBundle.php
+++ b/src/SomeWorkCqrsBundle.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle;
 
+use SomeWork\CqrsBundle\DependencyInjection\Compiler\CqrsHandlerPass;
 use SomeWork\CqrsBundle\DependencyInjection\CqrsExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SomeWorkCqrsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new CqrsHandlerPass());
+    }
+
     public function getContainerExtension(): ?ExtensionInterface
     {
         if (!$this->extension instanceof ExtensionInterface) {

--- a/src/Support/ClassNameMessageNamingStrategy.php
+++ b/src/Support/ClassNameMessageNamingStrategy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Contract\MessageNamingStrategy;
+
+/**
+ * Uses the short class name as the human readable message name.
+ */
+final class ClassNameMessageNamingStrategy implements MessageNamingStrategy
+{
+    public function getName(string $messageClass): string
+    {
+        $parts = explode('\\', $messageClass);
+
+        return end($parts) ?: $messageClass;
+    }
+}

--- a/src/Support/NullMessageSerializer.php
+++ b/src/Support/NullMessageSerializer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\MessageSerializer;
+use Symfony\Component\Messenger\Stamp\SerializerStamp;
+
+/**
+ * Message serializer that never applies additional stamps.
+ */
+final class NullMessageSerializer implements MessageSerializer
+{
+    public function getStamp(object $message, DispatchMode $mode): ?SerializerStamp
+    {
+        return null;
+    }
+}

--- a/src/Support/NullRetryPolicy.php
+++ b/src/Support/NullRetryPolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Retry policy that applies no additional stamps.
+ */
+final class NullRetryPolicy implements RetryPolicy
+{
+    /**
+     * @return list<StampInterface>
+     */
+    public function getStamps(object $message, DispatchMode $mode): array
+    {
+        return [];
+    }
+}

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Support\NullMessageSerializer;
+use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -24,7 +26,7 @@ final class CommandBusTest extends TestCase
             ->with($command, [])
             ->willReturn($envelope);
 
-        $bus = new CommandBus($syncBus);
+        $bus = new CommandBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($command));
     }
@@ -43,7 +45,7 @@ final class CommandBusTest extends TestCase
             ->with($command, [])
             ->willReturn($envelope);
 
-        $bus = new CommandBus($syncBus, $asyncBus);
+        $bus = new CommandBus($syncBus, $asyncBus, new NullRetryPolicy(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($command, DispatchMode::ASYNC));
     }
@@ -54,7 +56,7 @@ final class CommandBusTest extends TestCase
 
         $syncBus = $this->createMock(MessageBusInterface::class);
 
-        $bus = new CommandBus($syncBus);
+        $bus = new CommandBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Asynchronous command bus is not configured.');

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -8,10 +8,14 @@ use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\MessageSerializer;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\SerializerStamp;
 
 final class CommandBusTest extends TestCase
 {
@@ -60,6 +64,83 @@ final class CommandBusTest extends TestCase
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Asynchronous command bus is not configured.');
+
+        $bus->dispatch($command, DispatchMode::ASYNC);
+    }
+
+    public function test_dispatch_appends_retry_and_serializer_stamps(): void
+    {
+        $command = $this->createStub(Command::class);
+        $retryStamp = new DummyStamp('retry');
+        $serializerStamp = new SerializerStamp(['format' => 'json']);
+
+        $policy = $this->createMock(RetryPolicy::class);
+        $policy->expects(self::once())
+            ->method('getStamps')
+            ->with($command, DispatchMode::SYNC)
+            ->willReturn([$retryStamp]);
+
+        $serializer = $this->createMock(MessageSerializer::class);
+        $serializer->expects(self::once())
+            ->method('getStamp')
+            ->with($command, DispatchMode::SYNC)
+            ->willReturn($serializerStamp);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                $command,
+                self::callback(function (array $stamps) use ($retryStamp, $serializerStamp): bool {
+                    self::assertCount(2, $stamps);
+                    self::assertSame($retryStamp, $stamps[0]);
+                    self::assertSame($serializerStamp, $stamps[1]);
+
+                    return true;
+                })
+            )
+            ->willReturn(new Envelope($command));
+
+        $bus = new CommandBus($syncBus, null, $policy, $serializer);
+
+        $bus->dispatch($command);
+    }
+
+    public function test_dispatch_passes_mode_to_retry_policy_and_serializer(): void
+    {
+        $command = $this->createStub(Command::class);
+        $retryStamp = new DummyStamp('retry');
+        $serializerStamp = new SerializerStamp(['format' => 'json']);
+
+        $policy = $this->createMock(RetryPolicy::class);
+        $policy->expects(self::once())
+            ->method('getStamps')
+            ->with($command, DispatchMode::ASYNC)
+            ->willReturn([$retryStamp]);
+
+        $serializer = $this->createMock(MessageSerializer::class);
+        $serializer->expects(self::once())
+            ->method('getStamp')
+            ->with($command, DispatchMode::ASYNC)
+            ->willReturn($serializerStamp);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                $command,
+                self::callback(function (array $stamps) use ($retryStamp, $serializerStamp): bool {
+                    self::assertSame([$retryStamp, $serializerStamp], $stamps);
+
+                    return true;
+                })
+            )
+            ->willReturn(new Envelope($command));
+
+        $bus = new CommandBus($syncBus, $asyncBus, $policy, $serializer);
 
         $bus->dispatch($command, DispatchMode::ASYNC);
     }

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Bus\EventBus;
 use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Support\NullMessageSerializer;
+use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -24,7 +26,7 @@ final class EventBusTest extends TestCase
             ->with($event, [])
             ->willReturn($envelope);
 
-        $bus = new EventBus($syncBus);
+        $bus = new EventBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($event));
     }
@@ -43,7 +45,7 @@ final class EventBusTest extends TestCase
             ->with($event, [])
             ->willReturn($envelope);
 
-        $bus = new EventBus($syncBus, $asyncBus);
+        $bus = new EventBus($syncBus, $asyncBus, new NullRetryPolicy(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($event, DispatchMode::ASYNC));
     }
@@ -54,7 +56,7 @@ final class EventBusTest extends TestCase
 
         $syncBus = $this->createMock(MessageBusInterface::class);
 
-        $bus = new EventBus($syncBus);
+        $bus = new EventBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Asynchronous event bus is not configured.');

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -97,4 +97,3 @@ final class QueryBusTest extends TestCase
         self::assertSame('result', $queryBus->ask($query, $userStamp));
     }
 }
-

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -7,6 +7,8 @@ namespace SomeWork\CqrsBundle\Tests\Bus;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\QueryBus;
 use SomeWork\CqrsBundle\Contract\Query;
+use SomeWork\CqrsBundle\Support\NullMessageSerializer;
+use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
@@ -26,7 +28,7 @@ final class QueryBusTest extends TestCase
             ->with($query, [])
             ->willReturn($envelope);
 
-        $queryBus = new QueryBus($bus);
+        $queryBus = new QueryBus($bus, new NullRetryPolicy(), new NullMessageSerializer());
 
         self::assertSame('value', $queryBus->ask($query));
     }
@@ -42,7 +44,7 @@ final class QueryBusTest extends TestCase
             ->with($query, [])
             ->willReturn($envelope);
 
-        $queryBus = new QueryBus($bus);
+        $queryBus = new QueryBus($bus, new NullRetryPolicy(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Query was not handled by any handler.');

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace SomeWork\CqrsBundle\Tests\Bus;
 
 use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Bus\QueryBus;
+use SomeWork\CqrsBundle\Contract\MessageSerializer;
 use SomeWork\CqrsBundle\Contract\Query;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\SerializerStamp;
 
 final class QueryBusTest extends TestCase
 {
@@ -51,4 +56,45 @@ final class QueryBusTest extends TestCase
 
         $queryBus->ask($query);
     }
+
+    public function test_ask_merges_supplied_stamps_with_retry_and_serializer(): void
+    {
+        $query = $this->createStub(Query::class);
+        $userStamp = new DummyStamp('user');
+        $retryStamp = new DummyStamp('retry');
+        $serializerStamp = new SerializerStamp(['format' => 'json']);
+
+        $policy = $this->createMock(RetryPolicy::class);
+        $policy->expects(self::once())
+            ->method('getStamps')
+            ->with($query, DispatchMode::SYNC)
+            ->willReturn([$retryStamp]);
+
+        $serializer = $this->createMock(MessageSerializer::class);
+        $serializer->expects(self::once())
+            ->method('getStamp')
+            ->with($query, DispatchMode::SYNC)
+            ->willReturn($serializerStamp);
+
+        $handled = new HandledStamp('result', 'handler');
+        $envelope = (new Envelope($query))->with($handled);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                $query,
+                self::callback(function (array $stamps) use ($userStamp, $retryStamp, $serializerStamp): bool {
+                    self::assertSame([$userStamp, $retryStamp, $serializerStamp], $stamps);
+
+                    return true;
+                })
+            )
+            ->willReturn($envelope);
+
+        $queryBus = new QueryBus($bus, $policy, $serializer);
+
+        self::assertSame('result', $queryBus->ask($query, $userStamp));
+    }
 }
+

--- a/tests/Command/GenerateMessageCommandTest.php
+++ b/tests/Command/GenerateMessageCommandTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Command\GenerateMessageCommand;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class GenerateMessageCommandTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/cqrs_bundle_'.uniqid();
+        mkdir($this->projectDir.'/src', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->projectDir);
+    }
+
+    public function test_generates_message_and_handler_files(): void
+    {
+        $kernel = $this->createKernelStub();
+        $tester = new CommandTester(new GenerateMessageCommand($kernel));
+
+        $exitCode = $tester->execute([
+            'type' => 'command',
+            'name' => 'App\\Application\\Command\\ShipOrder',
+        ]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+        self::assertStringContainsString('Generated src/App/Application/Command/ShipOrder.php', $tester->getDisplay());
+
+        $messagePath = $this->projectDir.'/src/App/Application/Command/ShipOrder.php';
+        $handlerPath = $this->projectDir.'/src/App/Application/Command/ShipOrderHandler.php';
+
+        self::assertFileExists($messagePath);
+        self::assertFileExists($handlerPath);
+
+        $messageContents = file_get_contents($messagePath);
+        self::assertStringContainsString('final class ShipOrder implements Command', $messageContents ?: '');
+
+        $handlerContents = file_get_contents($handlerPath);
+        self::assertStringContainsString('#[AsCommandHandler(ShipOrder::class)]', $handlerContents ?: '');
+        self::assertStringContainsString('public function __invoke(ShipOrder $message): mixed', $handlerContents ?: '');
+    }
+
+    public function test_fails_when_files_exist_without_force(): void
+    {
+        $kernel = $this->createKernelStub();
+        $messagePath = $this->projectDir.'/src/App/Application/Command/ShipOrder.php';
+        $handlerPath = $this->projectDir.'/src/App/Application/Command/ShipOrderHandler.php';
+        mkdir(dirname($messagePath), 0777, true);
+        file_put_contents($messagePath, 'existing');
+        file_put_contents($handlerPath, 'existing');
+
+        $tester = new CommandTester(new GenerateMessageCommand($kernel));
+
+        $exitCode = $tester->execute([
+            'type' => 'command',
+            'name' => 'App\\Application\\Command\\ShipOrder',
+        ]);
+
+        self::assertSame(SymfonyCommand::FAILURE, $exitCode);
+        self::assertStringContainsString('already exists', $tester->getDisplay());
+        self::assertSame('existing', file_get_contents($messagePath));
+    }
+
+    public function test_invalid_type_displays_error(): void
+    {
+        $kernel = $this->createKernelStub();
+        $tester = new CommandTester(new GenerateMessageCommand($kernel));
+
+        $exitCode = $tester->execute([
+            'type' => 'unknown',
+            'name' => 'App\\Message',
+        ]);
+
+        self::assertSame(SymfonyCommand::FAILURE, $exitCode);
+        self::assertStringContainsString('Supported types are: command, query, event.', $tester->getDisplay());
+    }
+
+    private function createKernelStub(): KernelInterface
+    {
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getProjectDir')->willReturn($this->projectDir);
+
+        return $kernel;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($directory);
+    }
+}
+

--- a/tests/Command/GenerateMessageCommandTest.php
+++ b/tests/Command/GenerateMessageCommandTest.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+use function dirname;
+
 final class GenerateMessageCommandTest extends TestCase
 {
     private string $projectDir;
@@ -17,7 +19,7 @@ final class GenerateMessageCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->projectDir = sys_get_temp_dir().'/cqrs_bundle_'.uniqid();
-        mkdir($this->projectDir.'/src', 0777, true);
+        mkdir($this->projectDir.'/src', 0o777, true);
     }
 
     protected function tearDown(): void
@@ -57,7 +59,7 @@ final class GenerateMessageCommandTest extends TestCase
         $kernel = $this->createKernelStub();
         $messagePath = $this->projectDir.'/src/App/Application/Command/ShipOrder.php';
         $handlerPath = $this->projectDir.'/src/App/Application/Command/ShipOrderHandler.php';
-        mkdir(dirname($messagePath), 0777, true);
+        mkdir(dirname($messagePath), 0o777, true);
         file_put_contents($messagePath, 'existing');
         file_put_contents($handlerPath, 'existing');
 
@@ -117,4 +119,3 @@ final class GenerateMessageCommandTest extends TestCase
         rmdir($directory);
     }
 }
-

--- a/tests/Command/ListHandlersCommandTest.php
+++ b/tests/Command/ListHandlersCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use SomeWork\CqrsBundle\Command\ListHandlersCommand;
+use SomeWork\CqrsBundle\Contract\MessageNamingStrategy;
+use SomeWork\CqrsBundle\Registry\HandlerRegistry;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ListHandlersCommandTest extends TestCase
+{
+    public function test_lists_all_handlers_sorted_by_type_and_name(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [[
+                'type' => 'command',
+                'message' => 'App\\Application\\Command\\ShipOrder',
+                'handler_class' => 'App\\Application\\Command\\ShipOrderHandler',
+                'service_id' => 'app.command.ship_order_handler',
+                'bus' => 'messenger.bus.commands',
+            ]],
+            'query' => [[
+                'type' => 'query',
+                'message' => 'App\\ReadModel\\Query\\FindOrder',
+                'handler_class' => 'App\\ReadModel\\Query\\FindOrderHandler',
+                'service_id' => 'app.read_model.find_order_handler',
+                'bus' => null,
+            ]],
+            'event' => [],
+        ], [
+            'default' => 'Find order',
+            'command' => 'Ship order',
+        ]);
+
+        $tester = new CommandTester(new ListHandlersCommand($registry));
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+        $output = $tester->getDisplay();
+
+        self::assertStringContainsString('Command', $output);
+        self::assertStringContainsString('Query', $output);
+        self::assertStringContainsString('Ship order', $output);
+        self::assertStringContainsString('Find order', $output);
+
+        $commandIndex = strpos($output, 'Ship order');
+        $queryIndex = strpos($output, 'Find order');
+        self::assertIsInt($commandIndex);
+        self::assertIsInt($queryIndex);
+        self::assertLessThan($queryIndex, $commandIndex);
+    }
+
+    public function test_filters_by_type_option(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [[
+                'type' => 'command',
+                'message' => 'App\\Application\\Command\\ShipOrder',
+                'handler_class' => 'App\\Application\\Command\\ShipOrderHandler',
+                'service_id' => 'app.command.ship_order_handler',
+                'bus' => null,
+            ]],
+            'query' => [[
+                'type' => 'query',
+                'message' => 'App\\ReadModel\\Query\\FindOrder',
+                'handler_class' => 'App\\ReadModel\\Query\\FindOrderHandler',
+                'service_id' => 'app.read_model.find_order_handler',
+                'bus' => null,
+            ]],
+            'event' => [],
+        ], [
+            'default' => 'Default',
+            'command' => 'Ship order',
+            'query' => 'Find order',
+        ]);
+
+        $tester = new CommandTester(new ListHandlersCommand($registry));
+
+        $exitCode = $tester->execute(['--type' => ['command']]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+        $output = $tester->getDisplay();
+
+        self::assertStringContainsString('Ship order', $output);
+        self::assertStringNotContainsString('Find order', $output);
+    }
+
+    public function test_warns_when_no_handlers_found(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [],
+            'query' => [],
+            'event' => [],
+        ], [
+            'default' => 'Default',
+        ]);
+
+        $tester = new CommandTester(new ListHandlersCommand($registry));
+
+        $exitCode = $tester->execute(['--type' => ['unknown']]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+        self::assertStringContainsString('No CQRS handlers were found', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<string, list<array{type: string, message: class-string, handler_class: class-string, service_id: string, bus: string|null}>> $metadata
+     * @param array<string, string> $labels
+     */
+    private function createRegistry(array $metadata, array $labels): HandlerRegistry
+    {
+        $strategies = [];
+        foreach ($labels as $type => $label) {
+            $strategies[$type] = $this->labelStrategy($label);
+        }
+
+        if (!isset($strategies['default'])) {
+            $strategies['default'] = $this->labelStrategy('default');
+        }
+
+        $container = new class($strategies) implements ContainerInterface {
+            /** @param array<string, MessageNamingStrategy> $strategies */
+            public function __construct(private readonly array $strategies)
+            {
+            }
+
+            public function get(string $id): MessageNamingStrategy
+            {
+                return $this->strategies[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->strategies);
+            }
+        };
+
+        return new HandlerRegistry($metadata, $container);
+    }
+
+    private function labelStrategy(string $label): MessageNamingStrategy
+    {
+        return new class($label) implements MessageNamingStrategy {
+            public function __construct(private readonly string $label)
+            {
+            }
+
+            public function getName(string $messageClass): string
+            {
+                return $this->label;
+            }
+        };
+    }
+}
+

--- a/tests/Fixture/DummyStamp.php
+++ b/tests/Fixture/DummyStamp.php
@@ -12,4 +12,3 @@ final class DummyStamp implements StampInterface
     {
     }
 }
-

--- a/tests/Fixture/DummyStamp.php
+++ b/tests/Fixture/DummyStamp.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final class DummyStamp implements StampInterface
+{
+    public function __construct(public readonly string $name)
+    {
+    }
+}
+

--- a/tests/Functional/ConsoleCommandKernelTest.php
+++ b/tests/Functional/ConsoleCommandKernelTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Functional;
+
+use SomeWork\CqrsBundle\Tests\Fixture\Kernel\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ConsoleCommandKernelTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function test_list_command_outputs_registered_handlers(): void
+    {
+        $tester = $this->executeCommand('somework:cqrs:list');
+
+        self::assertSame(SymfonyCommand::SUCCESS, $tester->getStatusCode());
+
+        $display = $tester->getDisplay(true);
+
+        self::assertStringContainsString('Type', $display);
+        self::assertStringContainsString('CreateTaskCommand', $display);
+        self::assertStringContainsString('GenerateReportCommand', $display);
+        self::assertStringContainsString('FindTaskQuery', $display);
+        self::assertStringContainsString('TaskCreatedEvent', $display);
+        self::assertStringContainsString('messenger.bus.commands_async', $display);
+        self::assertStringContainsString('messenger.bus.events_async', $display);
+    }
+
+    public function test_list_command_supports_filtering_by_type(): void
+    {
+        $tester = $this->executeCommand('somework:cqrs:list', ['--type' => ['query']]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $tester->getStatusCode());
+
+        $display = $tester->getDisplay(true);
+
+        self::assertStringContainsString('FindTaskQuery', $display);
+        self::assertStringNotContainsString('CreateTaskCommand', $display);
+        self::assertStringNotContainsString('TaskCreatedEvent', $display);
+    }
+
+    private function executeCommand(string $name, array $input = []): CommandTester
+    {
+        $kernel = self::$kernel;
+        self::assertNotNull($kernel);
+
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $command = $application->find($name);
+        $tester = new CommandTester($command);
+        $tester->execute($input);
+
+        return $tester;
+    }
+}

--- a/tests/Functional/HandlerRegistryKernelTest.php
+++ b/tests/Functional/HandlerRegistryKernelTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Functional;
+
+use SomeWork\CqrsBundle\Registry\HandlerDescriptor;
+use SomeWork\CqrsBundle\Registry\HandlerRegistry;
+use SomeWork\CqrsBundle\Tests\Fixture\Kernel\TestKernel;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\GenerateReportCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class HandlerRegistryKernelTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function test_registry_exposes_command_handlers_with_bus_information(): void
+    {
+        $registry = static::getContainer()->get(HandlerRegistry::class);
+
+        $commands = $registry->byType('command');
+
+        $actual = array_map(
+            static fn (HandlerDescriptor $descriptor): array => [
+                $descriptor->messageClass,
+                $descriptor->handlerClass,
+                $descriptor->bus,
+            ],
+            $commands,
+        );
+
+        usort($actual, static fn (array $left, array $right): int => $left[0] <=> $right[0]);
+
+        self::assertSame(
+            [
+                [CreateTaskCommand::class, 'SomeWork\\CqrsBundle\\Tests\\Fixture\\Handler\\CreateTaskHandler', 'messenger.bus.commands'],
+                [GenerateReportCommand::class, 'SomeWork\\CqrsBundle\\Tests\\Fixture\\Handler\\GenerateReportHandler', 'messenger.bus.commands_async'],
+            ],
+            $actual,
+        );
+    }
+
+    public function test_registry_exposes_query_handlers(): void
+    {
+        $registry = static::getContainer()->get(HandlerRegistry::class);
+
+        $queries = $registry->byType('query');
+
+        self::assertCount(1, $queries);
+
+        $descriptor = $queries[0];
+        self::assertSame(FindTaskQuery::class, $descriptor->messageClass);
+        self::assertSame('SomeWork\\CqrsBundle\\Tests\\Fixture\\Handler\\FindTaskHandler', $descriptor->handlerClass);
+        self::assertSame('messenger.bus.queries', $descriptor->bus);
+    }
+
+    public function test_registry_exposes_event_handlers_across_buses(): void
+    {
+        $registry = static::getContainer()->get(HandlerRegistry::class);
+
+        $events = $registry->byType('event');
+
+        self::assertCount(2, $events);
+
+        $map = [];
+        foreach ($events as $descriptor) {
+            $map[$descriptor->handlerClass] = [$descriptor->messageClass, $descriptor->bus];
+        }
+
+        self::assertSame(
+            [TaskCreatedEvent::class, 'messenger.bus.events'],
+            $map['SomeWork\\CqrsBundle\\Tests\\Fixture\\Handler\\TaskNotificationHandler'],
+        );
+        self::assertSame(
+            [TaskCreatedEvent::class, 'messenger.bus.events_async'],
+            $map['SomeWork\\CqrsBundle\\Tests\\Fixture\\Handler\\AsyncProjectionHandler'],
+        );
+    }
+
+    public function test_registry_uses_naming_strategy_for_display_name(): void
+    {
+        $registry = static::getContainer()->get(HandlerRegistry::class);
+
+        $descriptor = null;
+        foreach ($registry->byType('command') as $candidate) {
+            if (CreateTaskCommand::class === $candidate->messageClass) {
+                $descriptor = $candidate;
+
+                break;
+            }
+        }
+
+        self::assertNotNull($descriptor);
+        self::assertSame('CreateTaskCommand', $registry->getDisplayName($descriptor));
+    }
+}

--- a/tests/Registry/HandlerRegistryTest.php
+++ b/tests/Registry/HandlerRegistryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Registry;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use SomeWork\CqrsBundle\Contract\MessageNamingStrategy;
+use SomeWork\CqrsBundle\Registry\HandlerDescriptor;
+use SomeWork\CqrsBundle\Registry\HandlerRegistry;
+
+final class HandlerRegistryTest extends TestCase
+{
+    public function test_all_returns_descriptors_for_each_entry(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [
+                [
+                    'type' => 'command',
+                    'message' => 'App\\Command\\ShipOrder',
+                    'handler_class' => 'App\\Command\\ShipOrderHandler',
+                    'service_id' => 'app.command.ship_order_handler',
+                    'bus' => 'messenger.bus.commands',
+                ],
+            ],
+            'query' => [
+                [
+                    'type' => 'query',
+                    'message' => 'App\\Query\\FindOrder',
+                    'handler_class' => 'App\\Query\\FindOrderHandler',
+                    'service_id' => 'app.query.find_order_handler',
+                    'bus' => null,
+                ],
+            ],
+        ], [
+            'default' => $this->strategy('Default %s'),
+            'command' => $this->strategy('Command %s'),
+        ]);
+
+        $descriptors = $registry->all();
+
+        self::assertCount(2, $descriptors);
+        self::assertContainsOnlyInstancesOf(HandlerDescriptor::class, $descriptors);
+        self::assertSame('Command App\\Command\\ShipOrder', $registry->getDisplayName($descriptors[0]));
+        self::assertSame('Default App\\Query\\FindOrder', $registry->getDisplayName($descriptors[1]));
+    }
+
+    public function test_by_type_filters_descriptors(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [
+                [
+                    'type' => 'command',
+                    'message' => 'App\\Command\\ShipOrder',
+                    'handler_class' => 'App\\Command\\ShipOrderHandler',
+                    'service_id' => 'app.command.ship_order_handler',
+                    'bus' => null,
+                ],
+            ],
+        ], [
+            'default' => $this->strategy('%s'),
+        ]);
+
+        $descriptors = $registry->byType('command');
+
+        self::assertCount(1, $descriptors);
+        self::assertSame('App\\Command\\ShipOrder', $descriptors[0]->messageClass);
+    }
+
+    private function createRegistry(array $metadata, array $strategies): HandlerRegistry
+    {
+        $container = new class($strategies) implements ContainerInterface {
+            /** @param array<string, MessageNamingStrategy> $strategies */
+            public function __construct(private readonly array $strategies)
+            {
+            }
+
+            public function get(string $id): MessageNamingStrategy
+            {
+                return $this->strategies[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->strategies);
+            }
+        };
+
+        return new HandlerRegistry($metadata, $container);
+    }
+
+    private function strategy(string $format): MessageNamingStrategy
+    {
+        return new class($format) implements MessageNamingStrategy {
+            public function __construct(private readonly string $format)
+            {
+            }
+
+            public function getName(string $messageClass): string
+            {
+                return sprintf($this->format, $messageClass);
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add configurable naming strategies, retry policies, and serializer stamps for CQRS buses
- introduce a compiler pass, handler registry, and console commands for listing handlers and scaffolding messages
- document attribute/interface usage and configuration options in README and docs/

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dab4dbd3348320a30d54e76c68b7be