### PR TITLE
Support interface-based retry policy overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,19 @@ somework_cqrs:
     naming:
         default: SomeWork\CqrsBundle\Support\ClassNameMessageNamingStrategy
     retry_policies:
-        command: SomeWork\CqrsBundle\Support\NullRetryPolicy
+        command:
+            default: SomeWork\CqrsBundle\Support\NullRetryPolicy
+            map:
+                App\Application\Command\ShipOrder: app.command.retry_policy
+                App\Domain\Contract\RequiresImmediateRetry: app.command.retry_policy_for_interface
     serialization:
         command: SomeWork\CqrsBundle\Support\NullMessageSerializer
 ```
+
+Use the `map` section inside each `retry_policies` entry to override the
+default policy for specific messages while keeping a shared fallback for the
+rest of the type. Keys may reference concrete messages, parent classes, or
+interfaces so you can coordinate retry behaviour across a group of messages.
 
 See [`docs/reference.md`](docs/reference.md) for a complete description of every
 option and [`docs/usage.md`](docs/usage.md) for more examples.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,9 +20,18 @@ somework_cqrs:
         query: null                                     # falls back to default
         event: null
     retry_policies:
-        command: SomeWork\CqrsBundle\Support\NullRetryPolicy
-        query: app.query_retry_policy
-        event: SomeWork\CqrsBundle\Support\NullRetryPolicy
+        command:
+            default: SomeWork\CqrsBundle\Support\NullRetryPolicy
+            map:
+                App\Application\Command\ShipOrder: app.command.retry_policy
+                App\Domain\Contract\RequiresImmediateRetry: app.command.retry_policy_for_interface
+        query:
+            default: app.query_retry_policy
+            map: {}
+        event:
+            default: SomeWork\CqrsBundle\Support\NullRetryPolicy
+            map:
+                App\Domain\Event\OrderShipped: app.event.retry_policy
     serialization:
         command: SomeWork\CqrsBundle\Support\NullMessageSerializer
         query: app.query_serializer
@@ -37,9 +46,12 @@ somework_cqrs:
   `SomeWork\CqrsBundle\Contract\MessageNamingStrategy`. They control the human
   readable message names exposed in CLI tooling and diagnostics.
 * **retry_policies** – services implementing
-  `SomeWork\CqrsBundle\Contract\RetryPolicy`. The buses merge the returned
-  stamps into each dispatch call so you can apply custom retry strategies per
-  message type.
+  `SomeWork\CqrsBundle\Contract\RetryPolicy`. Each section defines a `default`
+  service applied to the entire message type and an optional `map` of
+  message-specific overrides. Keys inside `map` may reference a concrete
+  message class, a parent class, or an interface implemented by the message.
+  The buses merge the returned stamps into each dispatch call so you can tailor
+  retry behaviour per message or shared contracts.
 * **serialization** – services implementing
   `SomeWork\CqrsBundle\Contract\MessageSerializer`. When the service returns a
   `SerializerStamp` it is appended to the dispatch call.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,7 @@ use SomeWork\CqrsBundle\Support\ClassNameMessageNamingStrategy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -105,22 +106,13 @@ final class Configuration implements ConfigurationInterface
         $retry = $children->arrayNode('retry_policies');
         $retry
             ->addDefaultsIfNotSet()
-            ->info('Retry policy services applied when dispatching messages.');
+            ->info('Retry policy services applied when dispatching messages. Supports per-message overrides.');
 
         /** @var ArrayNodeDefinition $retryChildren */
         $retryChildren = $retry->children();
-        $retryChildren
-            ->scalarNode('command')
-            ->defaultValue(NullRetryPolicy::class)
-            ->info('RetryPolicy service id applied to commands.');
-        $retryChildren
-            ->scalarNode('event')
-            ->defaultValue(NullRetryPolicy::class)
-            ->info('RetryPolicy service id applied to events.');
-        $retryChildren
-            ->scalarNode('query')
-            ->defaultValue(NullRetryPolicy::class)
-            ->info('RetryPolicy service id applied to queries.');
+        $this->configureRetryPolicySection($retryChildren, 'command');
+        $this->configureRetryPolicySection($retryChildren, 'event');
+        $this->configureRetryPolicySection($retryChildren, 'query');
         $retryChildren->end();
         $retry->end();
 
@@ -147,5 +139,29 @@ final class Configuration implements ConfigurationInterface
         $serialization->end();
 
         return $treeBuilder;
+    }
+
+    private function configureRetryPolicySection(NodeBuilder $parent, string $type): void
+    {
+        $node = $parent->arrayNode($type);
+        $node
+            ->addDefaultsIfNotSet()
+            ->info(sprintf('RetryPolicy services applied to %s messages.', $type));
+
+        $children = $node->children();
+        $children
+            ->scalarNode('default')
+            ->defaultValue(NullRetryPolicy::class)
+            ->info(sprintf('Fallback RetryPolicy service id applied to %s messages.', $type));
+
+        $children
+            ->arrayNode('map')
+            ->useAttributeAsKey('message')
+            ->scalarPrototype()
+            ->end()
+            ->info('Message-specific RetryPolicy service ids. Keys must match the message FQCN.');
+
+        $children->end();
+        $node->end();
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,8 @@ use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+use function sprintf;
+
 final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -10,10 +10,10 @@ use SomeWork\CqrsBundle\Attribute\AsQueryHandler;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\EventBus;
 use SomeWork\CqrsBundle\Bus\QueryBus;
-use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Contract\CommandHandler;
 use SomeWork\CqrsBundle\Contract\EventHandler;
 use SomeWork\CqrsBundle\Contract\QueryHandler;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -24,6 +24,8 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+
+use function sprintf;
 
 final class CqrsExtension extends Extension
 {

--- a/src/Support/RetryPolicyResolver.php
+++ b/src/Support/RetryPolicyResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use Psr\Container\ContainerInterface;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * Resolves the RetryPolicy to apply for a given message class.
+ */
+final class RetryPolicyResolver
+{
+    public function __construct(
+        private readonly RetryPolicy $defaultPolicy,
+        private readonly ContainerInterface $policies,
+    ) {
+    }
+
+    public static function withoutOverrides(?RetryPolicy $defaultPolicy = null): self
+    {
+        return new self($defaultPolicy ?? new NullRetryPolicy(), new ServiceLocator([]));
+    }
+
+    public function resolveFor(object $message): RetryPolicy
+    {
+        $messageClass = $message::class;
+
+        foreach ($this->classHierarchy($messageClass) as $type) {
+            if ($this->policies->has($type)) {
+                return $this->assertPolicy($type, $this->policies->get($type));
+            }
+        }
+
+        foreach ($this->interfaces($messageClass) as $interface) {
+            if ($this->policies->has($interface)) {
+                return $this->assertPolicy($interface, $this->policies->get($interface));
+            }
+        }
+
+        return $this->defaultPolicy;
+    }
+
+    /**
+     * @return iterable<class-string>
+     */
+    private function classHierarchy(string $class): iterable
+    {
+        for ($type = $class; false !== $type; $type = get_parent_class($type)) {
+            yield $type;
+        }
+    }
+
+    /**
+     * @return iterable<class-string>
+     */
+    private function interfaces(string $class): iterable
+    {
+        $seen = [];
+
+        foreach ($this->classHierarchy($class) as $type) {
+            foreach (class_implements($type, false) as $interface) {
+                if (isset($seen[$interface])) {
+                    continue;
+                }
+
+                $seen[$interface] = true;
+
+                yield $interface;
+            }
+        }
+    }
+
+    private function assertPolicy(string $type, mixed $service): RetryPolicy
+    {
+        if (!$service instanceof RetryPolicy) {
+            throw new \LogicException(sprintf('Retry policy override for "%s" must implement %s.', $type, RetryPolicy::class));
+        }
+
+        return $service;
+    }
+}

--- a/src/Support/RetryPolicyResolver.php
+++ b/src/Support/RetryPolicyResolver.php
@@ -8,6 +8,8 @@ use Psr\Container\ContainerInterface;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
+use function sprintf;
+
 /**
  * Resolves the RetryPolicy to apply for a given message class.
  */

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -14,10 +14,10 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class CommandBusTest extends TestCase
 {

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -7,21 +7,23 @@ namespace SomeWork\CqrsBundle\Tests\Bus;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
-use SomeWork\CqrsBundle\Contract\Command;
 use SomeWork\CqrsBundle\Contract\MessageSerializer;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
-use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class CommandBusTest extends TestCase
 {
     public function test_dispatch_uses_sync_bus_by_default(): void
     {
-        $command = $this->createStub(Command::class);
+        $command = new CreateTaskCommand('123', 'Test');
         $envelope = new Envelope($command);
 
         $syncBus = $this->createMock(MessageBusInterface::class);
@@ -30,14 +32,14 @@ final class CommandBusTest extends TestCase
             ->with($command, [])
             ->willReturn($envelope);
 
-        $bus = new CommandBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new CommandBus($syncBus, null, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($command));
     }
 
     public function test_dispatch_to_async_bus_when_configured(): void
     {
-        $command = $this->createStub(Command::class);
+        $command = new CreateTaskCommand('123', 'Test');
         $envelope = new Envelope($command);
 
         $syncBus = $this->createMock(MessageBusInterface::class);
@@ -49,18 +51,18 @@ final class CommandBusTest extends TestCase
             ->with($command, [])
             ->willReturn($envelope);
 
-        $bus = new CommandBus($syncBus, $asyncBus, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new CommandBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($command, DispatchMode::ASYNC));
     }
 
     public function test_async_dispatch_without_bus_throws_exception(): void
     {
-        $command = $this->createStub(Command::class);
+        $command = new CreateTaskCommand('123', 'Test');
 
         $syncBus = $this->createMock(MessageBusInterface::class);
 
-        $bus = new CommandBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new CommandBus($syncBus, null, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Asynchronous command bus is not configured.');
@@ -70,7 +72,7 @@ final class CommandBusTest extends TestCase
 
     public function test_dispatch_appends_retry_and_serializer_stamps(): void
     {
-        $command = $this->createStub(Command::class);
+        $command = new CreateTaskCommand('123', 'Test');
         $retryStamp = new DummyStamp('retry');
         $serializerStamp = new SerializerStamp(['format' => 'json']);
 
@@ -101,19 +103,24 @@ final class CommandBusTest extends TestCase
             )
             ->willReturn(new Envelope($command));
 
-        $bus = new CommandBus($syncBus, null, $policy, $serializer);
+        $resolver = new RetryPolicyResolver($policy, new ServiceLocator([]));
+
+        $bus = new CommandBus($syncBus, null, $resolver, $serializer);
 
         $bus->dispatch($command);
     }
 
     public function test_dispatch_passes_mode_to_retry_policy_and_serializer(): void
     {
-        $command = $this->createStub(Command::class);
+        $command = new CreateTaskCommand('123', 'Test');
         $retryStamp = new DummyStamp('retry');
         $serializerStamp = new SerializerStamp(['format' => 'json']);
 
-        $policy = $this->createMock(RetryPolicy::class);
-        $policy->expects(self::once())
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $messagePolicy = $this->createMock(RetryPolicy::class);
+        $messagePolicy->expects(self::once())
             ->method('getStamps')
             ->with($command, DispatchMode::ASYNC)
             ->willReturn([$retryStamp]);
@@ -140,8 +147,54 @@ final class CommandBusTest extends TestCase
             )
             ->willReturn(new Envelope($command));
 
-        $bus = new CommandBus($syncBus, $asyncBus, $policy, $serializer);
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                CreateTaskCommand::class => static fn (): RetryPolicy => $messagePolicy,
+            ])
+        );
+
+        $bus = new CommandBus($syncBus, $asyncBus, $resolver, $serializer);
 
         $bus->dispatch($command, DispatchMode::ASYNC);
+    }
+
+    public function test_dispatch_uses_retry_policy_bound_to_interface(): void
+    {
+        $command = new CreateTaskCommand('123', 'Test');
+        $retryStamp = new DummyStamp('retry');
+
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $interfacePolicy = $this->createMock(RetryPolicy::class);
+        $interfacePolicy->expects(self::once())
+            ->method('getStamps')
+            ->with($command, DispatchMode::SYNC)
+            ->willReturn([$retryStamp]);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                $command,
+                self::callback(function (array $stamps) use ($retryStamp): bool {
+                    self::assertSame([$retryStamp], $stamps);
+
+                    return true;
+                })
+            )
+            ->willReturn(new Envelope($command));
+
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                RetryAwareMessage::class => static fn (): RetryPolicy => $interfacePolicy,
+            ])
+        );
+
+        $bus = new CommandBus($syncBus, null, $resolver, new NullMessageSerializer());
+
+        $bus->dispatch($command);
     }
 }

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -7,21 +7,23 @@ namespace SomeWork\CqrsBundle\Tests\Bus;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Bus\EventBus;
-use SomeWork\CqrsBundle\Contract\Event;
 use SomeWork\CqrsBundle\Contract\MessageSerializer;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
-use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class EventBusTest extends TestCase
 {
     public function test_dispatch_uses_sync_bus_by_default(): void
     {
-        $event = $this->createStub(Event::class);
+        $event = new TaskCreatedEvent('123');
         $envelope = new Envelope($event);
 
         $syncBus = $this->createMock(MessageBusInterface::class);
@@ -30,14 +32,14 @@ final class EventBusTest extends TestCase
             ->with($event, [])
             ->willReturn($envelope);
 
-        $bus = new EventBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new EventBus($syncBus, null, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($event));
     }
 
     public function test_dispatch_to_async_bus_when_configured(): void
     {
-        $event = $this->createStub(Event::class);
+        $event = new TaskCreatedEvent('123');
         $envelope = new Envelope($event);
 
         $syncBus = $this->createMock(MessageBusInterface::class);
@@ -49,18 +51,18 @@ final class EventBusTest extends TestCase
             ->with($event, [])
             ->willReturn($envelope);
 
-        $bus = new EventBus($syncBus, $asyncBus, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new EventBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         self::assertSame($envelope, $bus->dispatch($event, DispatchMode::ASYNC));
     }
 
     public function test_async_dispatch_without_bus_throws_exception(): void
     {
-        $event = $this->createStub(Event::class);
+        $event = new TaskCreatedEvent('123');
 
         $syncBus = $this->createMock(MessageBusInterface::class);
 
-        $bus = new EventBus($syncBus, null, new NullRetryPolicy(), new NullMessageSerializer());
+        $bus = new EventBus($syncBus, null, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Asynchronous event bus is not configured.');
@@ -70,7 +72,7 @@ final class EventBusTest extends TestCase
 
     public function test_dispatch_applies_retry_policy_and_serializer(): void
     {
-        $event = $this->createStub(Event::class);
+        $event = new TaskCreatedEvent('123');
         $retryStamp = new DummyStamp('retry');
         $serializerStamp = new SerializerStamp(['format' => 'json']);
 
@@ -99,7 +101,78 @@ final class EventBusTest extends TestCase
             )
             ->willReturn(new Envelope($event));
 
-        $bus = new EventBus($syncBus, null, $policy, $serializer);
+        $resolver = new RetryPolicyResolver($policy, new ServiceLocator([]));
+
+        $bus = new EventBus($syncBus, null, $resolver, $serializer);
+
+        $bus->dispatch($event);
+    }
+
+    public function test_dispatch_uses_message_specific_retry_policy_for_async_mode(): void
+    {
+        $event = new TaskCreatedEvent('123');
+        $retryStamp = new DummyStamp('retry');
+
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $eventPolicy = $this->createMock(RetryPolicy::class);
+        $eventPolicy->expects(self::once())
+            ->method('getStamps')
+            ->with($event, DispatchMode::ASYNC)
+            ->willReturn([$retryStamp]);
+
+        $serializer = new NullMessageSerializer();
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [$retryStamp])
+            ->willReturn(new Envelope($event));
+
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                TaskCreatedEvent::class => static fn (): RetryPolicy => $eventPolicy,
+            ])
+        );
+
+        $bus = new EventBus($syncBus, $asyncBus, $resolver, $serializer);
+
+        $bus->dispatch($event, DispatchMode::ASYNC);
+    }
+
+    public function test_dispatch_uses_retry_policy_bound_to_interface(): void
+    {
+        $event = new TaskCreatedEvent('123');
+        $retryStamp = new DummyStamp('retry');
+
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $interfacePolicy = $this->createMock(RetryPolicy::class);
+        $interfacePolicy->expects(self::once())
+            ->method('getStamps')
+            ->with($event, DispatchMode::SYNC)
+            ->willReturn([$retryStamp]);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [$retryStamp])
+            ->willReturn(new Envelope($event));
+
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                RetryAwareMessage::class => static fn (): RetryPolicy => $interfacePolicy,
+            ])
+        );
+
+        $bus = new EventBus($syncBus, null, $resolver, new NullMessageSerializer());
 
         $bus->dispatch($event);
     }

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -12,12 +12,12 @@ use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
-use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class EventBusTest extends TestCase
 {

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -8,21 +8,23 @@ use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Bus\QueryBus;
 use SomeWork\CqrsBundle\Contract\MessageSerializer;
-use SomeWork\CqrsBundle\Contract\Query;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
-use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class QueryBusTest extends TestCase
 {
     public function test_ask_returns_handled_result(): void
     {
-        $query = $this->createStub(Query::class);
+        $query = new FindTaskQuery('123');
 
         $handled = new HandledStamp('value', 'handler');
         $envelope = (new Envelope($query))->with($handled);
@@ -33,14 +35,14 @@ final class QueryBusTest extends TestCase
             ->with($query, [])
             ->willReturn($envelope);
 
-        $queryBus = new QueryBus($bus, new NullRetryPolicy(), new NullMessageSerializer());
+        $queryBus = new QueryBus($bus, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         self::assertSame('value', $queryBus->ask($query));
     }
 
     public function test_ask_without_result_throws_exception(): void
     {
-        $query = $this->createStub(Query::class);
+        $query = new FindTaskQuery('123');
         $envelope = new Envelope($query);
 
         $bus = $this->createMock(MessageBusInterface::class);
@@ -49,7 +51,7 @@ final class QueryBusTest extends TestCase
             ->with($query, [])
             ->willReturn($envelope);
 
-        $queryBus = new QueryBus($bus, new NullRetryPolicy(), new NullMessageSerializer());
+        $queryBus = new QueryBus($bus, RetryPolicyResolver::withoutOverrides(), new NullMessageSerializer());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Query was not handled by any handler.');
@@ -59,13 +61,16 @@ final class QueryBusTest extends TestCase
 
     public function test_ask_merges_supplied_stamps_with_retry_and_serializer(): void
     {
-        $query = $this->createStub(Query::class);
+        $query = new FindTaskQuery('123');
         $userStamp = new DummyStamp('user');
         $retryStamp = new DummyStamp('retry');
         $serializerStamp = new SerializerStamp(['format' => 'json']);
 
-        $policy = $this->createMock(RetryPolicy::class);
-        $policy->expects(self::once())
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $queryPolicy = $this->createMock(RetryPolicy::class);
+        $queryPolicy->expects(self::once())
             ->method('getStamps')
             ->with($query, DispatchMode::SYNC)
             ->willReturn([$retryStamp]);
@@ -92,8 +97,50 @@ final class QueryBusTest extends TestCase
             )
             ->willReturn($envelope);
 
-        $queryBus = new QueryBus($bus, $policy, $serializer);
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                FindTaskQuery::class => static fn (): RetryPolicy => $queryPolicy,
+            ])
+        );
+
+        $queryBus = new QueryBus($bus, $resolver, $serializer);
 
         self::assertSame('result', $queryBus->ask($query, $userStamp));
+    }
+
+    public function test_ask_uses_retry_policy_bound_to_interface(): void
+    {
+        $query = new FindTaskQuery('123');
+        $retryStamp = new DummyStamp('retry');
+
+        $defaultPolicy = $this->createMock(RetryPolicy::class);
+        $defaultPolicy->expects(self::never())->method('getStamps');
+
+        $interfacePolicy = $this->createMock(RetryPolicy::class);
+        $interfacePolicy->expects(self::once())
+            ->method('getStamps')
+            ->with($query, DispatchMode::SYNC)
+            ->willReturn([$retryStamp]);
+
+        $handled = new HandledStamp('result', 'handler');
+        $envelope = (new Envelope($query))->with($handled);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with($query, [$retryStamp])
+            ->willReturn($envelope);
+
+        $resolver = new RetryPolicyResolver(
+            $defaultPolicy,
+            new ServiceLocator([
+                RetryAwareMessage::class => static fn (): RetryPolicy => $interfacePolicy,
+            ])
+        );
+
+        $queryBus = new QueryBus($bus, $resolver, new NullMessageSerializer());
+
+        self::assertSame('result', $queryBus->ask($query));
     }
 }

--- a/tests/Bus/QueryBusTest.php
+++ b/tests/Bus/QueryBusTest.php
@@ -14,11 +14,11 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class QueryBusTest extends TestCase
 {

--- a/tests/Fixture/Message/CreateTaskCommand.php
+++ b/tests/Fixture/Message/CreateTaskCommand.php
@@ -9,7 +9,7 @@ use SomeWork\CqrsBundle\Contract\Command;
 /**
  * Immutable command representing a request to create a task aggregate.
  */
-final class CreateTaskCommand implements Command
+final class CreateTaskCommand implements Command, RetryAwareMessage
 {
     public function __construct(
         public readonly string $id,

--- a/tests/Fixture/Message/FindTaskQuery.php
+++ b/tests/Fixture/Message/FindTaskQuery.php
@@ -9,7 +9,7 @@ use SomeWork\CqrsBundle\Contract\Query;
 /**
  * Query retrieving the name of a task by id.
  */
-final class FindTaskQuery implements Query
+final class FindTaskQuery implements Query, RetryAwareMessage
 {
     public function __construct(public readonly string $taskId)
     {

--- a/tests/Fixture/Message/RetryAwareMessage.php
+++ b/tests/Fixture/Message/RetryAwareMessage.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+interface RetryAwareMessage
+{
+}

--- a/tests/Fixture/Message/TaskCreatedEvent.php
+++ b/tests/Fixture/Message/TaskCreatedEvent.php
@@ -9,7 +9,7 @@ use SomeWork\CqrsBundle\Contract\Event;
 /**
  * Domain event emitted whenever a task has been created.
  */
-final class TaskCreatedEvent implements Event
+final class TaskCreatedEvent implements Event, RetryAwareMessage
 {
     public function __construct(public readonly string $taskId)
     {

--- a/tests/Support/RetryPolicyResolverTest.php
+++ b/tests/Support/RetryPolicyResolverTest.php
@@ -9,8 +9,8 @@ use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\NullRetryPolicy;
 use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
-use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class RetryPolicyResolverTest extends TestCase

--- a/tests/Support/RetryPolicyResolverTest.php
+++ b/tests/Support/RetryPolicyResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Contract\RetryPolicy;
+use SomeWork\CqrsBundle\Support\NullRetryPolicy;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\RetryAwareMessage;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class RetryPolicyResolverTest extends TestCase
+{
+    public function test_returns_default_policy_when_message_not_overridden(): void
+    {
+        $default = $this->createMock(RetryPolicy::class);
+        $resolver = new RetryPolicyResolver($default, new ServiceLocator([]));
+
+        $policy = $resolver->resolveFor(new CreateTaskCommand('1', 'Test'));
+
+        self::assertSame($default, $policy);
+    }
+
+    public function test_returns_overridden_policy_for_known_message(): void
+    {
+        $default = new NullRetryPolicy();
+        $override = $this->createMock(RetryPolicy::class);
+
+        $resolver = new RetryPolicyResolver($default, new ServiceLocator([
+            TaskCreatedEvent::class => static fn (): RetryPolicy => $override,
+        ]));
+
+        $policy = $resolver->resolveFor(new TaskCreatedEvent('1'));
+
+        self::assertSame($override, $policy);
+    }
+
+    public function test_returns_overridden_policy_for_interface(): void
+    {
+        $default = new NullRetryPolicy();
+        $interfacePolicy = $this->createMock(RetryPolicy::class);
+
+        $resolver = new RetryPolicyResolver($default, new ServiceLocator([
+            RetryAwareMessage::class => static fn (): RetryPolicy => $interfacePolicy,
+        ]));
+
+        $policy = $resolver->resolveFor(new CreateTaskCommand('1', 'Test'));
+
+        self::assertSame($interfacePolicy, $policy);
+    }
+}


### PR DESCRIPTION
## Summary
- update the retry policy resolver to inspect class hierarchies and interfaces when choosing an override
- exercise interface-based overrides across the command, event, and query buses with new tests
- document that retry policy maps accept classes, parent classes, or interfaces

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dad46eea80832090a0dd6bad2db20c