### PR TITLE
fix: respect dispatch mode overrides

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -78,9 +78,13 @@ somework_cqrs:
 * **dispatch_modes** – controls whether commands and events are dispatched
   synchronously or asynchronously when callers omit the `DispatchMode` argument.
   Each section defines a `default` mode (`sync` or `async`) plus a `map` of
-  message-specific overrides. When a message resolves to `async` the bundle
-  routes it through the configured asynchronous Messenger bus automatically. If
-  a caller explicitly passes a `DispatchMode`, that choice always wins.
+  message-specific overrides. Keys inside `map` may reference a concrete message
+  class, a parent class, or an interface implemented by the message. The decider
+  walks the class hierarchy and implemented interfaces from most to least
+  specific, so explicit class overrides beat interface ones. When a message
+  resolves to `async` the bundle routes it through the configured asynchronous
+  Messenger bus automatically. If a caller explicitly passes a `DispatchMode`,
+  that choice always wins.
   The `CommandBus` and `EventBus` also expose `dispatchSync()` and
   `dispatchAsync()` helpers that forward to `dispatch()` with the corresponding
   mode for convenience.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -81,6 +81,9 @@ somework_cqrs:
   message-specific overrides. When a message resolves to `async` the bundle
   routes it through the configured asynchronous Messenger bus automatically. If
   a caller explicitly passes a `DispatchMode`, that choice always wins.
+  The `CommandBus` and `EventBus` also expose `dispatchSync()` and
+  `dispatchAsync()` helpers that forward to `dispatch()` with the corresponding
+  mode for convenience.
 
 All options are optional. When you omit a setting the bundle falls back to a
 safe default implementation that leaves Messenger behaviour unchanged.

--- a/src/Bus/CommandBus.php
+++ b/src/Bus/CommandBus.php
@@ -11,7 +11,6 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
-
 /**
  * Dispatches commands through configured Messenger buses.
  */
@@ -19,32 +18,37 @@ final class CommandBus
 {
     private readonly RetryPolicyResolver $retryPolicies;
     private readonly MessageSerializerResolver $serializers;
+    private readonly DispatchModeDecider $dispatchModeDecider;
 
     public function __construct(
         private readonly MessageBusInterface $syncBus,
         private readonly ?MessageBusInterface $asyncBus = null,
         ?RetryPolicyResolver $retryPolicies = null,
         ?MessageSerializerResolver $serializers = null,
+        ?DispatchModeDecider $dispatchModeDecider = null,
     ) {
         $this->retryPolicies = $retryPolicies ?? RetryPolicyResolver::withoutOverrides();
         $this->serializers = $serializers ?? MessageSerializerResolver::withoutOverrides();
+        $this->dispatchModeDecider = $dispatchModeDecider ?? DispatchModeDecider::syncDefaults();
     }
 
     /**
      * @param list<StampInterface> $stamps
      */
-    public function dispatch(Command $command, DispatchMode $mode = DispatchMode::SYNC, StampInterface ...$stamps): Envelope
+    public function dispatch(Command $command, DispatchMode $mode = DispatchMode::DEFAULT, StampInterface ...$stamps): Envelope
     {
+        $resolvedMode = $this->dispatchModeDecider->resolve($command, $mode);
+
         $retryPolicy = $this->resolveRetryPolicy($command);
-        $stamps = [...$stamps, ...$retryPolicy->getStamps($command, $mode)];
+        $stamps = [...$stamps, ...$retryPolicy->getStamps($command, $resolvedMode)];
 
         $serializer = $this->serializers->resolveFor($command);
-        $serializerStamp = $serializer->getStamp($command, $mode);
+        $serializerStamp = $serializer->getStamp($command, $resolvedMode);
         if (null !== $serializerStamp) {
             $stamps[] = $serializerStamp;
         }
 
-        return $this->selectBus($mode)->dispatch($command, $stamps);
+        return $this->selectBus($resolvedMode)->dispatch($command, $stamps);
     }
 
     private function selectBus(DispatchMode $mode): MessageBusInterface

--- a/src/Bus/CommandBus.php
+++ b/src/Bus/CommandBus.php
@@ -51,6 +51,22 @@ final class CommandBus
         return $this->selectBus($resolvedMode)->dispatch($command, $stamps);
     }
 
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatchSync(Command $command, StampInterface ...$stamps): Envelope
+    {
+        return $this->dispatch($command, DispatchMode::SYNC, ...$stamps);
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatchAsync(Command $command, StampInterface ...$stamps): Envelope
+    {
+        return $this->dispatch($command, DispatchMode::ASYNC, ...$stamps);
+    }
+
     private function selectBus(DispatchMode $mode): MessageBusInterface
     {
         if (DispatchMode::ASYNC === $mode) {

--- a/src/Bus/CommandBus.php
+++ b/src/Bus/CommandBus.php
@@ -11,6 +11,7 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
+
 /**
  * Dispatches commands through configured Messenger buses.
  */

--- a/src/Bus/DispatchMode.php
+++ b/src/Bus/DispatchMode.php
@@ -9,6 +9,7 @@ namespace SomeWork\CqrsBundle\Bus;
  */
 enum DispatchMode: string
 {
+    case DEFAULT = 'default';
     case SYNC = 'sync';
     case ASYNC = 'async';
 }

--- a/src/Bus/DispatchModeDecider.php
+++ b/src/Bus/DispatchModeDecider.php
@@ -15,7 +15,7 @@ final class DispatchModeDecider
 {
     /**
      * @param array<class-string<Command>, DispatchMode> $commandMap
-     * @param array<class-string<Event>, DispatchMode> $eventMap
+     * @param array<class-string<Event>, DispatchMode>   $eventMap
      */
     public function __construct(
         private readonly DispatchMode $commandDefault,

--- a/src/Bus/DispatchModeDecider.php
+++ b/src/Bus/DispatchModeDecider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Bus;
+
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\Event;
+
+/**
+ * Resolves the effective dispatch mode for a message based on configuration.
+ */
+final class DispatchModeDecider
+{
+    /**
+     * @param array<class-string<Command>, DispatchMode> $commandMap
+     * @param array<class-string<Event>, DispatchMode> $eventMap
+     */
+    public function __construct(
+        private readonly DispatchMode $commandDefault,
+        private readonly DispatchMode $eventDefault,
+        private readonly array $commandMap = [],
+        private readonly array $eventMap = [],
+    ) {
+    }
+
+    public static function syncDefaults(): self
+    {
+        return new self(DispatchMode::SYNC, DispatchMode::SYNC);
+    }
+
+    public function resolve(object $message, DispatchMode $requested): DispatchMode
+    {
+        if (DispatchMode::DEFAULT !== $requested) {
+            return $requested;
+        }
+
+        if ($message instanceof Command) {
+            return $this->commandMap[$message::class] ?? $this->commandDefault;
+        }
+
+        if ($message instanceof Event) {
+            return $this->eventMap[$message::class] ?? $this->eventDefault;
+        }
+
+        return DispatchMode::SYNC;
+    }
+}

--- a/src/Bus/EventBus.php
+++ b/src/Bus/EventBus.php
@@ -51,6 +51,22 @@ final class EventBus
         return $this->selectBus($resolvedMode)->dispatch($event, $stamps);
     }
 
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatchSync(Event $event, StampInterface ...$stamps): Envelope
+    {
+        return $this->dispatch($event, DispatchMode::SYNC, ...$stamps);
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     */
+    public function dispatchAsync(Event $event, StampInterface ...$stamps): Envelope
+    {
+        return $this->dispatch($event, DispatchMode::ASYNC, ...$stamps);
+    }
+
     private function selectBus(DispatchMode $mode): MessageBusInterface
     {
         if (DispatchMode::ASYNC === $mode) {

--- a/src/Bus/EventBus.php
+++ b/src/Bus/EventBus.php
@@ -11,6 +11,7 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
+
 /**
  * Dispatches domain events through Messenger buses.
  */

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -7,6 +7,7 @@ namespace SomeWork\CqrsBundle\Tests\Bus;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\CommandBus;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Bus\DispatchModeDecider;
 use SomeWork\CqrsBundle\Contract\MessageSerializer;
 use SomeWork\CqrsBundle\Contract\RetryPolicy;
 use SomeWork\CqrsBundle\Support\MessageSerializerResolver;
@@ -55,6 +56,81 @@ final class CommandBusTest extends TestCase
         $bus = new CommandBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), MessageSerializerResolver::withoutOverrides());
 
         self::assertSame($envelope, $bus->dispatch($command, DispatchMode::ASYNC));
+    }
+
+    public function test_dispatch_uses_decider_default_when_mode_not_explicit(): void
+    {
+        $command = new CreateTaskCommand('123', 'Test');
+        $envelope = new Envelope($command);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($command, [])
+            ->willReturn($envelope);
+
+        $bus = new CommandBus(
+            $syncBus,
+            $asyncBus,
+            RetryPolicyResolver::withoutOverrides(),
+            MessageSerializerResolver::withoutOverrides(),
+            new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::SYNC),
+        );
+
+        self::assertSame($envelope, $bus->dispatch($command));
+    }
+
+    public function test_dispatch_uses_decider_map_override(): void
+    {
+        $command = new CreateTaskCommand('123', 'Test');
+        $envelope = new Envelope($command);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($command, [])
+            ->willReturn($envelope);
+
+        $bus = new CommandBus(
+            $syncBus,
+            $asyncBus,
+            RetryPolicyResolver::withoutOverrides(),
+            MessageSerializerResolver::withoutOverrides(),
+            new DispatchModeDecider(DispatchMode::SYNC, DispatchMode::SYNC, [CreateTaskCommand::class => DispatchMode::ASYNC]),
+        );
+
+        self::assertSame($envelope, $bus->dispatch($command));
+    }
+
+    public function test_explicit_mode_bypasses_decider(): void
+    {
+        $command = new CreateTaskCommand('123', 'Test');
+        $envelope = new Envelope($command);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($command, [])
+            ->willReturn($envelope);
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::never())->method('dispatch');
+
+        $bus = new CommandBus(
+            $syncBus,
+            $asyncBus,
+            RetryPolicyResolver::withoutOverrides(),
+            MessageSerializerResolver::withoutOverrides(),
+            new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::ASYNC),
+        );
+
+        self::assertSame($envelope, $bus->dispatch($command, DispatchMode::SYNC));
     }
 
     public function test_async_dispatch_without_bus_throws_exception(): void

--- a/tests/Bus/DispatchModeDeciderTest.php
+++ b/tests/Bus/DispatchModeDeciderTest.php
@@ -7,7 +7,12 @@ namespace SomeWork\CqrsBundle\Tests\Bus;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Bus\DispatchModeDecider;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\AuditLogEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\BulkImportCommand;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\HighPriorityEvent;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\ImportLegacyDataCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\OrderPlacedEvent;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
 
 final class DispatchModeDeciderTest extends TestCase
@@ -50,6 +55,67 @@ final class DispatchModeDeciderTest extends TestCase
         $decider = new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::ASYNC);
 
         $mode = $decider->resolve(new \stdClass(), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::SYNC, $mode);
+    }
+
+    public function test_command_interface_override_applies(): void
+    {
+        $decider = new DispatchModeDecider(
+            DispatchMode::SYNC,
+            DispatchMode::SYNC,
+            [BulkImportCommand::class => DispatchMode::ASYNC],
+        );
+
+        $mode = $decider->resolve(new ImportLegacyDataCommand('legacy.csv'), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::ASYNC, $mode);
+    }
+
+    public function test_event_interface_override_applies(): void
+    {
+        $decider = new DispatchModeDecider(
+            DispatchMode::SYNC,
+            DispatchMode::SYNC,
+            [],
+            [AuditLogEvent::class => DispatchMode::ASYNC],
+        );
+
+        $mode = $decider->resolve(new OrderPlacedEvent('order-1'), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::ASYNC, $mode);
+    }
+
+    public function test_more_specific_interface_takes_precedence(): void
+    {
+        $decider = new DispatchModeDecider(
+            DispatchMode::SYNC,
+            DispatchMode::SYNC,
+            [],
+            [
+                AuditLogEvent::class => DispatchMode::SYNC,
+                HighPriorityEvent::class => DispatchMode::ASYNC,
+            ],
+        );
+
+        $mode = $decider->resolve(new OrderPlacedEvent('order-1'), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::SYNC, $mode);
+    }
+
+    public function test_class_mapping_beats_interface_mapping(): void
+    {
+        $decider = new DispatchModeDecider(
+            DispatchMode::SYNC,
+            DispatchMode::SYNC,
+            [],
+            [
+                AuditLogEvent::class => DispatchMode::ASYNC,
+                OrderPlacedEvent::class => DispatchMode::SYNC,
+            ],
+        );
+
+        $mode = $decider->resolve(new OrderPlacedEvent('order-1'), DispatchMode::DEFAULT);
 
         self::assertSame(DispatchMode::SYNC, $mode);
     }

--- a/tests/Bus/DispatchModeDeciderTest.php
+++ b/tests/Bus/DispatchModeDeciderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Bus;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Bus\DispatchModeDecider;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+
+final class DispatchModeDeciderTest extends TestCase
+{
+    public function test_command_uses_configured_default(): void
+    {
+        $decider = new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::SYNC);
+
+        $mode = $decider->resolve(new CreateTaskCommand('id', 'name'), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::ASYNC, $mode);
+    }
+
+    public function test_event_map_overrides_default(): void
+    {
+        $event = new TaskCreatedEvent('task');
+        $decider = new DispatchModeDecider(
+            DispatchMode::SYNC,
+            DispatchMode::SYNC,
+            [],
+            [TaskCreatedEvent::class => DispatchMode::ASYNC],
+        );
+
+        $mode = $decider->resolve($event, DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::ASYNC, $mode);
+    }
+
+    public function test_explicit_mode_takes_precedence(): void
+    {
+        $decider = new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::ASYNC);
+
+        $mode = $decider->resolve(new CreateTaskCommand('id', 'name'), DispatchMode::SYNC);
+
+        self::assertSame(DispatchMode::SYNC, $mode);
+    }
+
+    public function test_non_cqrs_message_defaults_to_sync(): void
+    {
+        $decider = new DispatchModeDecider(DispatchMode::ASYNC, DispatchMode::ASYNC);
+
+        $mode = $decider->resolve(new \stdClass(), DispatchMode::DEFAULT);
+
+        self::assertSame(DispatchMode::SYNC, $mode);
+    }
+}

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -39,6 +39,25 @@ final class EventBusTest extends TestCase
         self::assertSame($envelope, $bus->dispatch($event));
     }
 
+    public function test_dispatch_sync_helper_uses_sync_bus(): void
+    {
+        $event = new TaskCreatedEvent('123');
+        $envelope = new Envelope($event);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [])
+            ->willReturn($envelope);
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::never())->method('dispatch');
+
+        $bus = new EventBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), MessageSerializerResolver::withoutOverrides());
+
+        self::assertSame($envelope, $bus->dispatchSync($event));
+    }
+
     public function test_dispatch_to_async_bus_when_configured(): void
     {
         $event = new TaskCreatedEvent('123');
@@ -56,6 +75,25 @@ final class EventBusTest extends TestCase
         $bus = new EventBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), MessageSerializerResolver::withoutOverrides());
 
         self::assertSame($envelope, $bus->dispatch($event, DispatchMode::ASYNC));
+    }
+
+    public function test_dispatch_async_helper_to_async_bus_when_configured(): void
+    {
+        $event = new TaskCreatedEvent('123');
+        $envelope = new Envelope($event);
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+        $syncBus->expects(self::never())->method('dispatch');
+
+        $asyncBus = $this->createMock(MessageBusInterface::class);
+        $asyncBus->expects(self::once())
+            ->method('dispatch')
+            ->with($event, [])
+            ->willReturn($envelope);
+
+        $bus = new EventBus($syncBus, $asyncBus, RetryPolicyResolver::withoutOverrides(), MessageSerializerResolver::withoutOverrides());
+
+        self::assertSame($envelope, $bus->dispatchAsync($event));
     }
 
     public function test_dispatch_uses_decider_default_when_mode_not_explicit(): void
@@ -145,6 +183,20 @@ final class EventBusTest extends TestCase
         $this->expectExceptionMessage('Asynchronous event bus is not configured.');
 
         $bus->dispatch($event, DispatchMode::ASYNC);
+    }
+
+    public function test_dispatch_async_helper_without_bus_throws_exception(): void
+    {
+        $event = new TaskCreatedEvent('123');
+
+        $syncBus = $this->createMock(MessageBusInterface::class);
+
+        $bus = new EventBus($syncBus, null, RetryPolicyResolver::withoutOverrides(), MessageSerializerResolver::withoutOverrides());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Asynchronous event bus is not configured.');
+
+        $bus->dispatchAsync($event);
     }
 
     public function test_dispatch_applies_retry_policy_and_serializer(): void

--- a/tests/Fixture/Message/AuditLogEvent.php
+++ b/tests/Fixture/Message/AuditLogEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+interface AuditLogEvent extends HighPriorityEvent
+{
+}

--- a/tests/Fixture/Message/BulkImportCommand.php
+++ b/tests/Fixture/Message/BulkImportCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Command;
+
+interface BulkImportCommand extends Command
+{
+}

--- a/tests/Fixture/Message/HighPriorityEvent.php
+++ b/tests/Fixture/Message/HighPriorityEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+use SomeWork\CqrsBundle\Contract\Event;
+
+interface HighPriorityEvent extends Event
+{
+}

--- a/tests/Fixture/Message/ImportLegacyDataCommand.php
+++ b/tests/Fixture/Message/ImportLegacyDataCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+final class ImportLegacyDataCommand implements BulkImportCommand
+{
+    public function __construct(public readonly string $source)
+    {
+    }
+}

--- a/tests/Fixture/Message/OrderPlacedEvent.php
+++ b/tests/Fixture/Message/OrderPlacedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Fixture\Message;
+
+final class OrderPlacedEvent implements AuditLogEvent
+{
+    public function __construct(public readonly string $orderId)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add a DispatchMode::DEFAULT sentinel that allows the buses to detect when configuration should decide
- update the command and event buses to rely on the decider for default requests while keeping explicit modes untouched
- extend decider tests to cover explicit overrides and non-CQRS messages defaulting to sync

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e2256217f48320934158f5536e4024