### PR TITLE
Add configurable message metadata providers for CQRS buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ tooling that keeps your catalogue maintainable.
 * PHP attributes (`#[AsCommandHandler]`, `#[AsQueryHandler]`, `#[AsEventHandler]`)
   and marker interfaces that auto-tag handlers for Messenger.
 * Console tooling to list registered handlers and scaffold new messages.
-* Configuration hooks for naming strategies, retry policies, and serializer
-  stamps.
+* Configuration hooks for naming strategies, retry policies, serializer stamps,
+  and metadata providers.
 * Plays nicely with multiple Messenger buses (sync and async).
 
 ## Quick start
@@ -118,6 +118,19 @@ somework_cqrs:
             default: SomeWork\CqrsBundle\Support\NullMessageSerializer
             map:
                 App\Domain\Event\OrderShipped: app.event.serializer
+    metadata:
+        default: SomeWork\CqrsBundle\Support\RandomCorrelationMetadataProvider
+        command:
+            default: null
+            map:
+                App\Application\Command\ShipOrder: app.command.metadata_provider
+        query:
+            default: null
+            map: {}
+        event:
+            default: null
+            map:
+                App\Domain\Event\OrderShipped: app.event.metadata_provider
     dispatch_modes:
         command:
             default: sync
@@ -148,6 +161,11 @@ every message type, override each type via its `default` entry, and list
 message-specific serializer services inside `map`. The buses check for
 message-specific serializers first, then fall back to the type default and
 finally to the global default.
+
+`metadata` controls which `MessageMetadataStamp` gets appended to dispatched
+messages. The bundle defaults to generating random correlation identifiers via
+`RandomCorrelationMetadataProvider`. Override the per-type `default` or
+configure `map` entries when you need deterministic IDs for specific messages.
 
 `dispatch_modes` lets you pick whether commands and events run on their
 synchronous or asynchronous Messenger buses when callers omit the `DispatchMode`

--- a/config/services.php
+++ b/config/services.php
@@ -19,6 +19,7 @@ return static function (ContainerConfigurator $configurator): void {
             '../src/DependencyInjection',
             '../src/Support/DispatchAfterCurrentBusDecider.php',
             '../src/Support/DispatchAfterCurrentBusStampDecider.php',
+            '../src/Support/MessageMetadataStampDecider.php',
             '../src/Support/MessageSerializerStampDecider.php',
             '../src/Support/StampsDecider.php',
             '../src/Support/StampDecider.php',

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,6 +45,19 @@ somework_cqrs:
             default: SomeWork\CqrsBundle\Support\NullMessageSerializer
             map:
                 App\Domain\Event\OrderShipped: app.event.serializer
+    metadata:
+        default: SomeWork\CqrsBundle\Support\RandomCorrelationMetadataProvider
+        command:
+            default: null
+            map:
+                App\Application\Command\ShipOrder: app.command.metadata_provider
+        query:
+            default: null
+            map: {}
+        event:
+            default: null
+            map:
+                App\Domain\Event\OrderShipped: app.event.metadata_provider
     dispatch_modes:
         command:
             default: sync
@@ -84,6 +97,13 @@ somework_cqrs:
   retry policy structure with a global `default`, per-type `default`, and a
   message-specific `map`. The buses resolve serializers in that order and append
   the returned `SerializerStamp` to the dispatch call when provided.
+* **metadata** – services implementing
+  `SomeWork\CqrsBundle\Contract\MessageMetadataProvider`. The configuration
+  mirrors the serializer structure with a global `default`, per-type `default`,
+  and per-message `map`. Providers return `MessageMetadataStamp` instances that
+  the bundle appends to dispatched messages. The default provider generates
+  random correlation identifiers, but you can replace it with deterministic
+  implementations for specific messages when required.
 * **dispatch_modes** – controls whether commands and events are dispatched
   synchronously or asynchronously when callers omit the `DispatchMode` argument.
   Each section defines a `default` mode (`sync` or `async`) plus a `map` of

--- a/src/Contract/MessageMetadataProvider.php
+++ b/src/Contract/MessageMetadataProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Contract;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Stamp\MessageMetadataStamp;
+
+/**
+ * Supplies metadata stamps applied when dispatching CQRS messages.
+ */
+interface MessageMetadataProvider
+{
+    public function getStamp(object $message, DispatchMode $mode): ?MessageMetadataStamp;
+}

--- a/src/Support/MessageMetadataProviderResolver.php
+++ b/src/Support/MessageMetadataProviderResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use Psr\Container\ContainerInterface;
+use SomeWork\CqrsBundle\Contract\MessageMetadataProvider;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+use function get_debug_type;
+use function sprintf;
+
+final class MessageMetadataProviderResolver
+{
+    public const GLOBAL_DEFAULT_KEY = '__somework_cqrs_metadata_global_default';
+    public const TYPE_DEFAULT_KEY = '__somework_cqrs_metadata_type_default';
+
+    public function __construct(
+        private readonly ContainerInterface $providers,
+    ) {
+    }
+
+    public static function withoutOverrides(?MessageMetadataProvider $defaultProvider = null): self
+    {
+        $provider = $defaultProvider ?? new RandomCorrelationMetadataProvider();
+
+        return new self(new ServiceLocator([
+            self::GLOBAL_DEFAULT_KEY => static fn (): MessageMetadataProvider => $provider,
+            self::TYPE_DEFAULT_KEY => static fn (): MessageMetadataProvider => $provider,
+        ]));
+    }
+
+    public function resolveFor(object $message): MessageMetadataProvider
+    {
+        $match = MessageTypeLocator::match(
+            $this->providers,
+            $message,
+            [self::GLOBAL_DEFAULT_KEY, self::TYPE_DEFAULT_KEY],
+        );
+
+        if (null !== $match) {
+            return $this->assertProvider($match->type, $match->service);
+        }
+
+        if ($this->providers->has(self::TYPE_DEFAULT_KEY)) {
+            return $this->assertProvider(self::TYPE_DEFAULT_KEY, $this->providers->get(self::TYPE_DEFAULT_KEY));
+        }
+
+        if (!$this->providers->has(self::GLOBAL_DEFAULT_KEY)) {
+            throw new \LogicException('Metadata provider resolver must be initialised with a global default provider.');
+        }
+
+        return $this->assertProvider(self::GLOBAL_DEFAULT_KEY, $this->providers->get(self::GLOBAL_DEFAULT_KEY));
+    }
+
+    private function assertProvider(string $key, mixed $service): MessageMetadataProvider
+    {
+        if ($service instanceof \Closure) {
+            $service = $service();
+        }
+
+        if (!$service instanceof MessageMetadataProvider) {
+            throw new \LogicException(sprintf('Metadata provider override for "%s" must implement %s, got %s.', $key, MessageMetadataProvider::class, get_debug_type($service)));
+        }
+
+        return $service;
+    }
+}

--- a/src/Support/MessageMetadataStampDecider.php
+++ b/src/Support/MessageMetadataStampDecider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Adds metadata stamps for supported messages.
+ */
+final class MessageMetadataStampDecider implements StampDecider
+{
+    /**
+     * @param class-string $messageType
+     */
+    public function __construct(
+        private readonly MessageMetadataProviderResolver $providers,
+        private readonly string $messageType,
+    ) {
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     *
+     * @return list<StampInterface>
+     */
+    public function decide(object $message, DispatchMode $mode, array $stamps): array
+    {
+        if (!$message instanceof $this->messageType) {
+            return $stamps;
+        }
+
+        $provider = $this->providers->resolveFor($message);
+        $metadataStamp = $provider->getStamp($message, $mode);
+
+        if (null === $metadataStamp) {
+            return $stamps;
+        }
+
+        $stamps[] = $metadataStamp;
+
+        return $stamps;
+    }
+}

--- a/src/Support/RandomCorrelationMetadataProvider.php
+++ b/src/Support/RandomCorrelationMetadataProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\MessageMetadataProvider;
+use SomeWork\CqrsBundle\Stamp\MessageMetadataStamp;
+
+/**
+ * Generates random correlation identifiers for dispatched messages.
+ */
+final class RandomCorrelationMetadataProvider implements MessageMetadataProvider
+{
+    public function getStamp(object $message, DispatchMode $mode): ?MessageMetadataStamp
+    {
+        return MessageMetadataStamp::createWithRandomCorrelationId();
+    }
+}

--- a/src/Support/StampsDecider.php
+++ b/src/Support/StampsDecider.php
@@ -7,6 +7,8 @@ namespace SomeWork\CqrsBundle\Support;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Contract\Command;
 use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Support\MessageMetadataProviderResolver;
+use SomeWork\CqrsBundle\Support\MessageMetadataStampDecider;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -29,17 +31,19 @@ final class StampsDecider implements StampDecider
     public static function withDefaultCommandDecorators(
         RetryPolicyResolver $retryPolicies,
         MessageSerializerResolver $serializers,
+        MessageMetadataProviderResolver $metadata,
         ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
     ): self {
-        return self::withDefaultsFor(Command::class, $retryPolicies, $serializers, $dispatchAfter);
+        return self::withDefaultsFor(Command::class, $retryPolicies, $serializers, $metadata, $dispatchAfter);
     }
 
     public static function withDefaultEventDecorators(
         RetryPolicyResolver $retryPolicies,
         MessageSerializerResolver $serializers,
+        MessageMetadataProviderResolver $metadata,
         ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
     ): self {
-        return self::withDefaultsFor(Event::class, $retryPolicies, $serializers, $dispatchAfter);
+        return self::withDefaultsFor(Event::class, $retryPolicies, $serializers, $metadata, $dispatchAfter);
     }
 
     public static function withoutDecorators(): self
@@ -65,11 +69,13 @@ final class StampsDecider implements StampDecider
         string $messageType,
         RetryPolicyResolver $retryPolicies,
         MessageSerializerResolver $serializers,
+        MessageMetadataProviderResolver $metadata,
         ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
     ): self {
         $deciders = [
             new RetryPolicyStampDecider($retryPolicies, $messageType),
             new MessageSerializerStampDecider($serializers, $messageType),
+            new MessageMetadataStampDecider($metadata, $messageType),
         ];
 
         $deciders[] = new DispatchAfterCurrentBusStampDecider($dispatchAfter ?? DispatchAfterCurrentBusDecider::defaults());

--- a/src/Support/StampsDecider.php
+++ b/src/Support/StampsDecider.php
@@ -7,8 +7,6 @@ namespace SomeWork\CqrsBundle\Support;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\Contract\Command;
 use SomeWork\CqrsBundle\Contract\Event;
-use SomeWork\CqrsBundle\Support\MessageMetadataProviderResolver;
-use SomeWork\CqrsBundle\Support\MessageMetadataStampDecider;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**

--- a/tests/Fixture/Service/TaskRecorder.php
+++ b/tests/Fixture/Service/TaskRecorder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\Tests\Fixture\Service;
 
+use SomeWork\CqrsBundle\Stamp\MessageMetadataStamp;
 use Symfony\Component\Messenger\Envelope;
 
 use function in_array;
@@ -28,6 +29,9 @@ final class TaskRecorder
     /** @var array<string, list<class-string<object>>> */
     private array $handledMessages = [];
 
+    /** @var array<string, list<MessageMetadataStamp>> */
+    private array $metadataStamps = [];
+
     public function reset(): void
     {
         $this->tasks = [];
@@ -35,6 +39,7 @@ final class TaskRecorder
         $this->events = [];
         $this->asyncEvents = [];
         $this->handledMessages = [];
+        $this->metadataStamps = [];
     }
 
     public function recordTask(string $id, string $name): void
@@ -86,6 +91,11 @@ final class TaskRecorder
     public function recordEnvelopeMessage(string $handlerClass, Envelope $envelope): void
     {
         $this->handledMessages[$handlerClass][] = $envelope->getMessage()::class;
+
+        $metadataStamp = $envelope->last(MessageMetadataStamp::class);
+        if ($metadataStamp instanceof MessageMetadataStamp) {
+            $this->metadataStamps[$handlerClass][] = $metadataStamp;
+        }
     }
 
     /**
@@ -94,5 +104,13 @@ final class TaskRecorder
     public function handledMessages(string $handlerClass): array
     {
         return $this->handledMessages[$handlerClass] ?? [];
+    }
+
+    /**
+     * @return list<MessageMetadataStamp>
+     */
+    public function metadataStamps(string $handlerClass): array
+    {
+        return $this->metadataStamps[$handlerClass] ?? [];
     }
 }

--- a/tests/Functional/MessengerIntegrationTest.php
+++ b/tests/Functional/MessengerIntegrationTest.php
@@ -92,5 +92,14 @@ final class MessengerIntegrationTest extends KernelTestCase
             [GenerateReportCommand::class],
             $recorder->handledMessages(GenerateReportHandler::class)
         );
+
+        $syncMetadata = $recorder->metadataStamps(CreateTaskHandler::class);
+        self::assertCount(1, $syncMetadata);
+        self::assertNotSame('', $syncMetadata[0]->getCorrelationId());
+
+        $asyncMetadata = $recorder->metadataStamps(GenerateReportHandler::class);
+        self::assertCount(1, $asyncMetadata);
+        self::assertNotSame('', $asyncMetadata[0]->getCorrelationId());
+        self::assertNotSame($syncMetadata[0]->getCorrelationId(), $asyncMetadata[0]->getCorrelationId());
     }
 }

--- a/tests/Support/MessageMetadataProviderResolverTest.php
+++ b/tests/Support/MessageMetadataProviderResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\MessageMetadataProvider;
+use SomeWork\CqrsBundle\Support\MessageMetadataProviderResolver;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class MessageMetadataProviderResolverTest extends TestCase
+{
+    public function test_resolves_provider_from_class_hierarchy(): void
+    {
+        $provider = $this->createMock(MessageMetadataProvider::class);
+
+        $resolver = new MessageMetadataProviderResolver(new ServiceLocator([
+            MessageMetadataProviderResolver::GLOBAL_DEFAULT_KEY => fn (): MessageMetadataProvider => $this->createMock(MessageMetadataProvider::class),
+            MessageMetadataProviderResolver::TYPE_DEFAULT_KEY => fn (): MessageMetadataProvider => $this->createMock(MessageMetadataProvider::class),
+            MessageMetadataProviderResolverTestParentCommand::class => static fn (): MessageMetadataProvider => $provider,
+        ]));
+
+        $resolved = $resolver->resolveFor(new MessageMetadataProviderResolverTestChildCommand());
+
+        self::assertSame($provider, $resolved);
+    }
+
+    public function test_resolves_provider_from_interface_hierarchy(): void
+    {
+        $provider = $this->createMock(MessageMetadataProvider::class);
+
+        $resolver = new MessageMetadataProviderResolver(new ServiceLocator([
+            MessageMetadataProviderResolver::GLOBAL_DEFAULT_KEY => fn (): MessageMetadataProvider => $this->createMock(MessageMetadataProvider::class),
+            MessageMetadataProviderResolver::TYPE_DEFAULT_KEY => fn (): MessageMetadataProvider => $this->createMock(MessageMetadataProvider::class),
+            MessageMetadataProviderResolverTestInterface::class => static fn (): MessageMetadataProvider => $provider,
+        ]));
+
+        $resolved = $resolver->resolveFor(new MessageMetadataProviderResolverTestInterfaceCommand());
+
+        self::assertSame($provider, $resolved);
+    }
+}
+
+class MessageMetadataProviderResolverTestParentCommand implements Command
+{
+}
+
+class MessageMetadataProviderResolverTestChildCommand extends MessageMetadataProviderResolverTestParentCommand
+{
+}
+
+interface MessageMetadataProviderResolverTestInterface extends Command
+{
+}
+
+class MessageMetadataProviderResolverTestInterfaceCommand implements MessageMetadataProviderResolverTestInterface
+{
+}

--- a/tests/Support/MessageMetadataStampDeciderTest.php
+++ b/tests/Support/MessageMetadataStampDeciderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\MessageMetadataProvider;
+use SomeWork\CqrsBundle\Stamp\MessageMetadataStamp;
+use SomeWork\CqrsBundle\Support\MessageMetadataProviderResolver;
+use SomeWork\CqrsBundle\Support\MessageMetadataStampDecider;
+use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+
+final class MessageMetadataStampDeciderTest extends TestCase
+{
+    public function test_appends_metadata_stamp_for_supported_messages(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+        $metadataStamp = MessageMetadataStamp::createWithRandomCorrelationId();
+
+        $provider = $this->createMock(MessageMetadataProvider::class);
+        $provider->expects(self::once())
+            ->method('getStamp')
+            ->with($message, DispatchMode::ASYNC)
+            ->willReturn($metadataStamp);
+
+        $resolver = MessageMetadataProviderResolver::withoutOverrides($provider);
+        $decider = new MessageMetadataStampDecider($resolver, Command::class);
+
+        $stamps = $decider->decide($message, DispatchMode::ASYNC, []);
+
+        self::assertSame([$metadataStamp], $stamps);
+    }
+
+    public function test_ignores_null_metadata_stamp(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+
+        $provider = $this->createMock(MessageMetadataProvider::class);
+        $provider->expects(self::once())
+            ->method('getStamp')
+            ->with($message, DispatchMode::ASYNC)
+            ->willReturn(null);
+
+        $existing = new DummyStamp('existing');
+
+        $resolver = MessageMetadataProviderResolver::withoutOverrides($provider);
+        $decider = new MessageMetadataStampDecider($resolver, Command::class);
+
+        $stamps = $decider->decide($message, DispatchMode::ASYNC, [$existing]);
+
+        self::assertSame([$existing], $stamps);
+    }
+
+    public function test_ignores_messages_of_unexpected_type(): void
+    {
+        $event = new TaskCreatedEvent('123');
+
+        $provider = $this->createMock(MessageMetadataProvider::class);
+        $provider->expects(self::never())->method('getStamp');
+
+        $existing = new DummyStamp('existing');
+
+        $resolver = MessageMetadataProviderResolver::withoutOverrides($provider);
+        $decider = new MessageMetadataStampDecider($resolver, Command::class);
+
+        $stamps = $decider->decide($event, DispatchMode::ASYNC, [$existing]);
+
+        self::assertSame([$existing], $stamps);
+    }
+}


### PR DESCRIPTION
## Summary
- add a MessageMetadataProvider contract, resolver, and random correlation provider plus a metadata stamp decider
- extend bundle configuration and DI wiring to register metadata providers and include them in the dispatch stamp pipeline
- document the metadata options and cover the new resolver/decider with unit and functional tests

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e292443efc83208066c0218b25c268