### PR TITLE
Validate async buses when dispatch modes use async

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -115,6 +115,11 @@ somework_cqrs:
   The `CommandBus` and `EventBus` also expose `dispatchSync()` and
   `dispatchAsync()` helpers that forward to `dispatch()` with the corresponding
   mode for convenience.
+  When any command or event resolves to `async` you must configure the matching
+  Messenger bus via `buses.command_async` or `buses.event_async`. The bundle
+  validates this at container-compilation time and throws an
+  `InvalidConfigurationException` when an async default or override exists
+  without the corresponding async bus id.
 * **async.dispatch_after_current_bus** – toggles whether the bundle appends
   Messenger's `DispatchAfterCurrentBusStamp` when a command or event resolves to
   the asynchronous bus. Leave the `default` values set to `true` to preserve the
@@ -159,6 +164,11 @@ message marked `async` – either via the `dispatch_modes` defaults or a
 per-message override – is delivered to the transport consumed by your workers.
 This keeps the CQRS facades consistent with the Messenger routing you already
 use for explicit async dispatch calls.
+Additionally, define the Messenger bus ids that back asynchronous dispatch
+(for example `messenger.bus.commands_async` or `messenger.bus.events_async`).
+The extension fails fast during container compilation if `dispatch_modes`
+resolve to `async` while the relevant async bus id remains `null`, ensuring you
+register the transport before deploying.
 
 ## Handler registry service
 

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -29,6 +29,7 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Support\RetryPolicyStampDecider;
 use SomeWork\CqrsBundle\Support\StampDecider;
 use SomeWork\CqrsBundle\Support\StampsDecider;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -57,6 +58,8 @@ final class CqrsExtension extends Extension
         $defaultBusId = $config['default_bus'] ?? 'messenger.default_bus';
         $container->setParameter('somework_cqrs.default_bus', $defaultBusId);
         $container->setParameter('somework_cqrs.handler_metadata', []);
+
+        $this->guardAsyncBusConfiguration($config);
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
@@ -379,6 +382,84 @@ final class CqrsExtension extends Extension
         $definition->setPublic(false);
 
         $container->setDefinition('somework_cqrs.dispatch_mode_decider', $definition);
+    }
+
+    /**
+     * @param array{
+     *     buses: array{
+     *         command?: string|null,
+     *         command_async?: string|null,
+     *         query?: string|null,
+     *         event?: string|null,
+     *         event_async?: string|null,
+     *     },
+     *     dispatch_modes: array{
+     *         command: array{default: string, map: array<string, string>},
+     *         event: array{default: string, map: array<string, string>},
+     *     },
+     * } $config
+     */
+    private function guardAsyncBusConfiguration(array $config): void
+    {
+        $commandAsyncBus = $config['buses']['command_async'] ?? null;
+        $eventAsyncBus = $config['buses']['event_async'] ?? null;
+
+        $commandAsyncSources = $this->collectAsyncSources($config['dispatch_modes']['command']);
+        if (null === $commandAsyncBus && ($commandAsyncSources['default'] || [] !== $commandAsyncSources['messages'])) {
+            $this->throwMissingAsyncBusException('command', $commandAsyncSources, 'command_async');
+        }
+
+        $eventAsyncSources = $this->collectAsyncSources($config['dispatch_modes']['event']);
+        if (null === $eventAsyncBus && ($eventAsyncSources['default'] || [] !== $eventAsyncSources['messages'])) {
+            $this->throwMissingAsyncBusException('event', $eventAsyncSources, 'event_async');
+        }
+    }
+
+    /**
+     * @param array{default: string, map: array<string, string>} $dispatchConfig
+     * @return array{default: bool, messages: list<string>}
+     */
+    private function collectAsyncSources(array $dispatchConfig): array
+    {
+        $messages = [];
+
+        foreach ($dispatchConfig['map'] as $messageClass => $mode) {
+            if (DispatchMode::ASYNC->value === $mode) {
+                $messages[] = $messageClass;
+            }
+        }
+
+        return [
+            'default' => DispatchMode::ASYNC->value === $dispatchConfig['default'],
+            'messages' => $messages,
+        ];
+    }
+
+    /**
+     * @param array{default: bool, messages: list<string>} $sources
+     */
+    private function throwMissingAsyncBusException(string $type, array $sources, string $busKey): void
+    {
+        $typeLabel = 'command' === $type ? 'commands' : 'events';
+
+        $parts = [];
+        if ($sources['default']) {
+            $parts[] = 'the default dispatch mode is "async"';
+        }
+        if ([] !== $sources['messages']) {
+            $parts[] = sprintf('async map entries: %s', implode(', ', $sources['messages']));
+        }
+
+        $details = implode(' and ', $parts);
+
+        throw new InvalidConfigurationException(sprintf(
+            'Asynchronous dispatch is configured for %s (%s), but "somework_cqrs.buses.%s" is null. '
+            .'Define the Messenger bus id used for async %s before the container is compiled.',
+            $typeLabel,
+            $details,
+            $busKey,
+            $typeLabel
+        ));
     }
 
     /**

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -417,6 +417,7 @@ final class CqrsExtension extends Extension
 
     /**
      * @param array{default: string, map: array<string, string>} $dispatchConfig
+     *
      * @return array{default: bool, messages: list<string>}
      */
     private function collectAsyncSources(array $dispatchConfig): array
@@ -452,14 +453,15 @@ final class CqrsExtension extends Extension
 
         $details = implode(' and ', $parts);
 
-        throw new InvalidConfigurationException(sprintf(
-            'Asynchronous dispatch is configured for %s (%s), but "somework_cqrs.buses.%s" is null. '
-            .'Define the Messenger bus id used for async %s before the container is compiled.',
+        $message = sprintf(
+            'Asynchronous dispatch is configured for %s (%s), but "somework_cqrs.buses.%s" is null. Define the Messenger bus id used for async %s before the container is compiled.',
             $typeLabel,
             $details,
             $busKey,
-            $typeLabel
-        ));
+            $typeLabel,
+        );
+
+        throw new InvalidConfigurationException($message);
     }
 
     /**

--- a/tests/DependencyInjection/CqrsExtensionAsyncValidationTest.php
+++ b/tests/DependencyInjection/CqrsExtensionAsyncValidationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\DependencyInjection\CqrsExtension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class CqrsExtensionAsyncValidationTest extends TestCase
+{
+    public function test_it_requires_async_command_bus_when_default_dispatch_is_async(): void
+    {
+        $extension = new CqrsExtension();
+        $container = new ContainerBuilder();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('somework_cqrs.buses.command_async');
+
+        $extension->load([
+            [
+                'dispatch_modes' => [
+                    'command' => [
+                        'default' => DispatchMode::ASYNC->value,
+                        'map' => [],
+                    ],
+                    'event' => [
+                        'default' => DispatchMode::SYNC->value,
+                        'map' => [],
+                    ],
+                ],
+            ],
+        ], $container);
+    }
+
+    public function test_it_requires_async_event_bus_when_async_map_entries_exist(): void
+    {
+        $extension = new CqrsExtension();
+        $container = new ContainerBuilder();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('somework_cqrs.buses.event_async');
+
+        $extension->load([
+            [
+                'dispatch_modes' => [
+                    'command' => [
+                        'default' => DispatchMode::SYNC->value,
+                        'map' => [],
+                    ],
+                    'event' => [
+                        'default' => DispatchMode::SYNC->value,
+                        'map' => [
+                            'App\\Domain\\Event\\OrderPlaced' => DispatchMode::ASYNC->value,
+                        ],
+                    ],
+                ],
+            ],
+        ], $container);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the CQRS extension fails fast when command or event dispatch defaults resolve to async but their async bus is missing
- cover the guard with regression tests exercising async defaults and per-message overrides
- document that enabling async dispatch requires wiring the corresponding Messenger buses

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e29a3a09e4832080daab7c1611fda6