### PR TITLE
Add detailed handler configuration reporting to list command

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -188,9 +188,10 @@ power diagnostics, smoke tests, or documentation pages. The registry exposes:
 Two console commands ship with the bundle:
 
 * `somework:cqrs:list` – Prints the handler catalogue in a table. Accepts the
-  `--type=<command|query|event>` option multiple times. The command is safe to
-  run in production and reflects the container compiled for the current
-  environment.
+  `--type=<command|query|event>` option multiple times. Add `--details` to the
+  command to include the resolved dispatch configuration for every handler. The
+  command is safe to run in production and reflects the container compiled for
+  the current environment.
 * `somework:cqrs:generate <type> <class>` – Scaffolds a message and handler pair
   for the chosen type. Optional flags:
   * `--handler=` to customise the handler class name.
@@ -198,3 +199,31 @@ Two console commands ship with the bundle:
   * `--force` to overwrite existing files instead of aborting.
 
 Both commands are registered automatically when the bundle is enabled.
+
+### Inspecting handler configuration
+
+Run the following command to inspect the effective configuration that the
+bundle applies to each message:
+
+```bash
+$ php bin/console somework:cqrs:list --details
+```
+
+The detailed view adds these columns to every row:
+
+* **Dispatch Mode** – The default `DispatchMode` resolved for the message when
+  callers do not pass an explicit mode.
+* **Async Defers** – Whether the bundle applies Messenger's
+  `DispatchAfterCurrentBusStamp` when the message is sent to an asynchronous
+  bus. The column is reported as `n/a` for message types without async support.
+* **Retry Policy** – The `RetryPolicy` service chosen after evaluating the
+  global, per-type, and per-message overrides.
+* **Serializer** – The `MessageSerializer` service that will contribute a
+  `SerializerStamp` when the message is dispatched.
+* **Metadata Provider** – The `MessageMetadataProvider` service that supplies
+  a `MessageMetadataStamp` for the message, typically containing correlation
+  identifiers.
+
+Use this output to verify how custom overrides are applied across your
+application or to debug unexpected dispatch behaviour in production
+environments.

--- a/src/Command/ListHandlersCommand.php
+++ b/src/Command/ListHandlersCommand.php
@@ -54,15 +54,24 @@ final class ListHandlersCommand extends Command
         private readonly HandlerRegistry $registry,
         private readonly DispatchModeDecider $dispatchModeDecider,
         private readonly DispatchAfterCurrentBusDecider $dispatchAfterCurrentBusDecider,
-        #[Autowire(service: 'somework_cqrs.retry.command_resolver')] RetryPolicyResolver $commandRetryResolver,
-        #[Autowire(service: 'somework_cqrs.retry.query_resolver')] RetryPolicyResolver $queryRetryResolver,
-        #[Autowire(service: 'somework_cqrs.retry.event_resolver')] RetryPolicyResolver $eventRetryResolver,
-        #[Autowire(service: 'somework_cqrs.serializer.command_resolver')] MessageSerializerResolver $commandSerializerResolver,
-        #[Autowire(service: 'somework_cqrs.serializer.query_resolver')] MessageSerializerResolver $querySerializerResolver,
-        #[Autowire(service: 'somework_cqrs.serializer.event_resolver')] MessageSerializerResolver $eventSerializerResolver,
-        #[Autowire(service: 'somework_cqrs.metadata.command_resolver')] MessageMetadataProviderResolver $commandMetadataResolver,
-        #[Autowire(service: 'somework_cqrs.metadata.query_resolver')] MessageMetadataProviderResolver $queryMetadataResolver,
-        #[Autowire(service: 'somework_cqrs.metadata.event_resolver')] MessageMetadataProviderResolver $eventMetadataResolver,
+        #[Autowire(service: 'somework_cqrs.retry.command_resolver')]
+        RetryPolicyResolver $commandRetryResolver,
+        #[Autowire(service: 'somework_cqrs.retry.query_resolver')]
+        RetryPolicyResolver $queryRetryResolver,
+        #[Autowire(service: 'somework_cqrs.retry.event_resolver')]
+        RetryPolicyResolver $eventRetryResolver,
+        #[Autowire(service: 'somework_cqrs.serializer.command_resolver')]
+        MessageSerializerResolver $commandSerializerResolver,
+        #[Autowire(service: 'somework_cqrs.serializer.query_resolver')]
+        MessageSerializerResolver $querySerializerResolver,
+        #[Autowire(service: 'somework_cqrs.serializer.event_resolver')]
+        MessageSerializerResolver $eventSerializerResolver,
+        #[Autowire(service: 'somework_cqrs.metadata.command_resolver')]
+        MessageMetadataProviderResolver $commandMetadataResolver,
+        #[Autowire(service: 'somework_cqrs.metadata.query_resolver')]
+        MessageMetadataProviderResolver $queryMetadataResolver,
+        #[Autowire(service: 'somework_cqrs.metadata.event_resolver')]
+        MessageMetadataProviderResolver $eventMetadataResolver,
     ) {
         parent::__construct();
 
@@ -239,7 +248,8 @@ final class ListHandlersCommand extends Command
 
     /**
      * @template T
-     * @param T|null $resolver
+     *
+     * @param T|null                      $resolver
      * @param callable(T, object): object $callback
      */
     private function describeResolvedService(mixed $resolver, ?object $message, callable $callback): string

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -382,6 +382,7 @@ final class CqrsExtension extends Extension
         $definition->setPublic(false);
 
         $container->setDefinition('somework_cqrs.dispatch_mode_decider', $definition);
+        $container->setAlias(DispatchModeDecider::class, 'somework_cqrs.dispatch_mode_decider')->setPublic(false);
     }
 
     /**
@@ -483,6 +484,7 @@ final class CqrsExtension extends Extension
         $definition->setPublic(false);
 
         $container->setDefinition('somework_cqrs.dispatch_after_current_bus_decider', $definition);
+        $container->setAlias(DispatchAfterCurrentBusDecider::class, 'somework_cqrs.dispatch_after_current_bus_decider')->setPublic(false);
     }
 
     private function registerStampsDecider(ContainerBuilder $container): void

--- a/tests/Functional/ConsoleCommandKernelTest.php
+++ b/tests/Functional/ConsoleCommandKernelTest.php
@@ -54,6 +54,23 @@ final class ConsoleCommandKernelTest extends KernelTestCase
         self::assertStringNotContainsString('TaskCreatedEvent', $display);
     }
 
+    public function test_list_command_reports_handler_configuration_details(): void
+    {
+        $tester = $this->executeCommand('somework:cqrs:list', ['--details' => true]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $tester->getStatusCode());
+
+        $display = $tester->getDisplay(true);
+
+        self::assertStringContainsString('Dispatch Mode', $display);
+        self::assertStringContainsString('Async Defers', $display);
+        self::assertStringContainsString('SomeWork\\CqrsBundle\\Support\\NullRetryPolicy', $display);
+        self::assertStringContainsString('SomeWork\\CqrsBundle\\Support\\NullMessageSerializer', $display);
+        self::assertStringContainsString('SomeWork\\CqrsBundle\\Support\\RandomCorrelationMetadataProvider', $display);
+        self::assertMatchesRegularExpression('/CreateTaskCommand[^\n]+sync[^\n]+yes/', $display);
+        self::assertMatchesRegularExpression('/FindTaskQuery[^\n]+sync[^\n]+n\/a/', $display);
+    }
+
     private function executeCommand(string $name, array $input = []): CommandTester
     {
         $kernel = self::$kernel;


### PR DESCRIPTION
## Summary
- add a --details flag to `somework:cqrs:list` that reports dispatch mode, async deferral, retry policy, serializer, and metadata for each handler
- wire the command to the configured deciders/resolvers and expose aliases for the shared services
- extend console documentation and functional coverage for the new detailed view

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e29deed230832087d06d45d5c385c9