### PR TITLE
Add coverage for list handlers command details output

### DIFF
--- a/tests/Command/ListHandlersCommandTest.php
+++ b/tests/Command/ListHandlersCommandTest.php
@@ -171,25 +171,21 @@ final class ListHandlersCommandTest extends TestCase
         self::assertStringContainsString('Serializer', $output);
         self::assertStringContainsString('Metadata Provider', $output);
 
-        self::assertStringContainsString(TestAsyncCommandHandler::class, $output);
-        self::assertStringContainsString(TestQueryHandler::class, $output);
-        self::assertStringContainsString(TestEventHandler::class, $output);
+        $retryClass = preg_quote(NullRetryPolicy::class, '/');
+        $serializerClass = preg_quote(NullMessageSerializer::class, '/');
+        $metadataClass = preg_quote(RandomCorrelationMetadataProvider::class, '/');
 
-        $retryClass = NullRetryPolicy::class;
-        $serializerClass = NullMessageSerializer::class;
-        $metadataClass = RandomCorrelationMetadataProvider::class;
+        $commandRowPattern = '/\|\s*Command\s*\|\s*Command label\s*\|\s*'.preg_quote(TestAsyncCommandHandler::class, '/').'\s*\|\s*app\\.command\\.async_handler\s*\|\s*messenger\\.bus\\.commands\s*\|\s*sync\s*\|\s*yes\s*\|\s*'.$retryClass.'\s*\|\s*'.$serializerClass.'\s*\|\s*'.$metadataClass.'\s*\|/';
+        self::assertMatchesRegularExpression($commandRowPattern, $output);
 
-        self::assertStringContainsString($retryClass, $output);
-        self::assertStringContainsString($serializerClass, $output);
-        self::assertStringContainsString($metadataClass, $output);
+        $eventRowPattern = '/\|\s*Event\s*\|\s*Event label\s*\|\s*'.preg_quote(TestEventHandler::class, '/').'\s*\|\s*app\\.event\\.handler\s*\|\s*messenger\\.bus\\.events\s*\|\s*async\s*\|\s*no\s*\|\s*'.$retryClass.'\s*\|\s*'.$serializerClass.'\s*\|\s*'.$metadataClass.'\s*\|/';
+        self::assertMatchesRegularExpression($eventRowPattern, $output);
 
-        self::assertMatchesRegularExpression('/\|\s*Command\s*\|\s*Command label\s*\|[^\n]+\|\s*messenger\\.bus\\.commands\s*\|\s*sync\s*\|\s*yes\s*\|/', $output);
+        $queryRowPattern = '/\|\s*Query\s*\|\s*Query label\s*\|\s*'.preg_quote(TestQueryHandler::class, '/').'\s*\|\s*app\\.query\\.handler\s*\|\s*default\s*\|\s*sync\s*\|\s*n\/a\s*\|\s*'.$retryClass.'\s*\|\s*'.$serializerClass.'\s*\|\s*'.$metadataClass.'\s*\|/';
+        self::assertMatchesRegularExpression($queryRowPattern, $output);
 
-        self::assertMatchesRegularExpression('/\|\s*Event\s*\|\s*Event label\s*\|[^\n]+\|\s*messenger\\.bus\\.events\s*\|\s*async\s*\|\s*no\s*\|/', $output);
-
-        self::assertMatchesRegularExpression('/\|\s*Query\s*\|\s*Query label\s*\|[^\n]+\|\s*default\s*\|\s*sync\s*\|\s*n\/a\s*\|\s*' . preg_quote($retryClass, '/') . '\s*\|\s*' . preg_quote($serializerClass, '/') . '\s*\|\s*' . preg_quote($metadataClass, '/') . '\s*\|/', $output);
-
-        self::assertMatchesRegularExpression('/app\\.command\\.broken_handler[^\n]+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a/', $output);
+        $brokenRowPattern = '/\|\s*Command\s*\|\s*Command label\s*\|\s*'.preg_quote(TestBrokenCommandHandler::class, '/').'\s*\|\s*app\\.command\\.broken_handler\s*\|\s*messenger\\.bus\\.commands\s*\|\s*n\/a\s*\|\s*n\/a\s*\|\s*n\/a\s*\|\s*n\/a\s*\|\s*n\/a\s*\|/';
+        self::assertMatchesRegularExpression($brokenRowPattern, $output);
     }
 
     /**
@@ -233,8 +229,7 @@ final class ListHandlersCommandTest extends TestCase
         HandlerRegistry $registry,
         ?DispatchModeDecider $dispatchModeDecider = null,
         ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
-    ): ListHandlersCommand
-    {
+    ): ListHandlersCommand {
         $dispatchModeDecider ??= new DispatchModeDecider(DispatchMode::SYNC, DispatchMode::SYNC);
         $dispatchAfter ??= DispatchAfterCurrentBusDecider::defaults();
 

--- a/tests/Command/ListHandlersCommandTest.php
+++ b/tests/Command/ListHandlersCommandTest.php
@@ -118,6 +118,80 @@ final class ListHandlersCommandTest extends TestCase
         self::assertStringContainsString('No CQRS handlers were found', $tester->getDisplay());
     }
 
+    public function test_details_option_displays_configuration_and_handles_uninstantiable_messages(): void
+    {
+        $registry = $this->createRegistry([
+            'command' => [[
+                'type' => 'command',
+                'message' => TestAsyncCommand::class,
+                'handler_class' => TestAsyncCommandHandler::class,
+                'service_id' => 'app.command.async_handler',
+                'bus' => 'messenger.bus.commands',
+            ], [
+                'type' => 'command',
+                'message' => TestBrokenCommand::class,
+                'handler_class' => TestBrokenCommandHandler::class,
+                'service_id' => 'app.command.broken_handler',
+                'bus' => 'messenger.bus.commands',
+            ]],
+            'query' => [[
+                'type' => 'query',
+                'message' => TestQuery::class,
+                'handler_class' => TestQueryHandler::class,
+                'service_id' => 'app.query.handler',
+                'bus' => null,
+            ]],
+            'event' => [[
+                'type' => 'event',
+                'message' => TestEvent::class,
+                'handler_class' => TestEventHandler::class,
+                'service_id' => 'app.event.handler',
+                'bus' => 'messenger.bus.events',
+            ]],
+        ], [
+            'default' => 'Default label',
+            'command' => 'Command label',
+            'query' => 'Query label',
+            'event' => 'Event label',
+        ]);
+
+        $dispatchModeDecider = new DispatchModeDecider(DispatchMode::SYNC, DispatchMode::ASYNC);
+        $dispatchAfter = new DispatchAfterCurrentBusDecider(true, new ServiceLocator([]), false, new ServiceLocator([]));
+
+        $tester = new CommandTester($this->createCommand($registry, $dispatchModeDecider, $dispatchAfter));
+
+        $exitCode = $tester->execute(['--details' => true]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+        $output = $tester->getDisplay();
+
+        self::assertStringContainsString('Dispatch Mode', $output);
+        self::assertStringContainsString('Async Defers', $output);
+        self::assertStringContainsString('Retry Policy', $output);
+        self::assertStringContainsString('Serializer', $output);
+        self::assertStringContainsString('Metadata Provider', $output);
+
+        self::assertStringContainsString(TestAsyncCommandHandler::class, $output);
+        self::assertStringContainsString(TestQueryHandler::class, $output);
+        self::assertStringContainsString(TestEventHandler::class, $output);
+
+        $retryClass = NullRetryPolicy::class;
+        $serializerClass = NullMessageSerializer::class;
+        $metadataClass = RandomCorrelationMetadataProvider::class;
+
+        self::assertStringContainsString($retryClass, $output);
+        self::assertStringContainsString($serializerClass, $output);
+        self::assertStringContainsString($metadataClass, $output);
+
+        self::assertMatchesRegularExpression('/\|\s*Command\s*\|\s*Command label\s*\|[^\n]+\|\s*messenger\\.bus\\.commands\s*\|\s*sync\s*\|\s*yes\s*\|/', $output);
+
+        self::assertMatchesRegularExpression('/\|\s*Event\s*\|\s*Event label\s*\|[^\n]+\|\s*messenger\\.bus\\.events\s*\|\s*async\s*\|\s*no\s*\|/', $output);
+
+        self::assertMatchesRegularExpression('/\|\s*Query\s*\|\s*Query label\s*\|[^\n]+\|\s*default\s*\|\s*sync\s*\|\s*n\/a\s*\|\s*' . preg_quote($retryClass, '/') . '\s*\|\s*' . preg_quote($serializerClass, '/') . '\s*\|\s*' . preg_quote($metadataClass, '/') . '\s*\|/', $output);
+
+        self::assertMatchesRegularExpression('/app\\.command\\.broken_handler[^\n]+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a\s+\|\s+n\/a/', $output);
+    }
+
     /**
      * @param array<string, list<array{type: string, message: class-string, handler_class: class-string, service_id: string, bus: string|null}>> $metadata
      * @param array<string, string>                                                                                                              $labels
@@ -155,10 +229,14 @@ final class ListHandlersCommandTest extends TestCase
         };
     }
 
-    private function createCommand(HandlerRegistry $registry): ListHandlersCommand
+    private function createCommand(
+        HandlerRegistry $registry,
+        ?DispatchModeDecider $dispatchModeDecider = null,
+        ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
+    ): ListHandlersCommand
     {
-        $dispatchModeDecider = new DispatchModeDecider(DispatchMode::SYNC, DispatchMode::SYNC);
-        $dispatchAfter = DispatchAfterCurrentBusDecider::defaults();
+        $dispatchModeDecider ??= new DispatchModeDecider(DispatchMode::SYNC, DispatchMode::SYNC);
+        $dispatchAfter ??= DispatchAfterCurrentBusDecider::defaults();
 
         $retryResolver = RetryPolicyResolver::withoutOverrides(new NullRetryPolicy());
         $serializerResolver = MessageSerializerResolver::withoutOverrides(new NullMessageSerializer());
@@ -179,4 +257,36 @@ final class ListHandlersCommandTest extends TestCase
             $metadataResolver,
         );
     }
+}
+
+interface TestBrokenCommand extends \SomeWork\CqrsBundle\Contract\Command
+{
+}
+
+final class TestAsyncCommand implements \SomeWork\CqrsBundle\Contract\Command
+{
+}
+
+final class TestAsyncCommandHandler
+{
+}
+
+final class TestBrokenCommandHandler
+{
+}
+
+final class TestQuery implements \SomeWork\CqrsBundle\Contract\Query
+{
+}
+
+final class TestQueryHandler
+{
+}
+
+final class TestEvent implements \SomeWork\CqrsBundle\Contract\Event
+{
+}
+
+final class TestEventHandler
+{
 }


### PR DESCRIPTION
## Summary
- extend ListHandlersCommandTest to exercise the --details flag with async, sync, and uninstantiable message scenarios
- add local test doubles for commands, queries, events, and handlers to verify resolver outputs and fallbacks
- allow the test helper to accept custom dispatch deciders for flexible assertions

## Testing
- `vendor/bin/phpunit tests/Command/ListHandlersCommandTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e2a655df788320bcd9e7961bfa1640