### PR TITLE
docs: add installation guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@ tooling that keeps your catalogue maintainable.
   and metadata providers.
 * Plays nicely with multiple Messenger buses (sync and async).
 
+## Installation
+
+### Requirements
+
+* PHP 8.2 or newer.
+* Symfony FrameworkBundle 6.4 or 7.x.
+* Symfony Messenger 6.4 or 7.x.
+
+Install the bundle via Composer:
+
+```bash
+composer require somework/cqrs-bundle
+```
+
+Then enable it in `config/bundles.php`:
+
+```php
+return [
+    // ...
+    SomeWork\CqrsBundle\SomeWorkCqrsBundle::class => ['all' => true],
+];
+```
+
+Run the bundled console tooling to verify the bundle is registered:
+
+```bash
+bin/console somework:cqrs:list
+```
+
 ## Quick start
 
 ```php


### PR DESCRIPTION
## Summary
- add installation section that includes requirements and composer command
- document enabling the bundle and verifying it via the console tooling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2aaaa24a083208a1b4b35bad20e8f