### PR TITLE
Fix handler locator decoration for aliased messenger buses

### DIFF
--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -148,7 +148,8 @@ final class CqrsExtension extends Extension
         $busIds = array_values(array_unique($busIds));
 
         foreach ($busIds as $busId) {
-            $locatorId = sprintf('%s.messenger.handlers_locator', $busId);
+            $resolvedBusId = $this->resolveBusServiceId($container, $busId);
+            $locatorId = sprintf('%s.messenger.handlers_locator', $resolvedBusId);
 
             $decoratorId = sprintf('somework_cqrs.envelope_aware_handlers_locator.%s', md5($locatorId));
 
@@ -156,6 +157,15 @@ final class CqrsExtension extends Extension
                 ->setDecoratedService($locatorId)
                 ->setArgument('$decorated', new Reference($decoratorId.'.inner'));
         }
+    }
+
+    private function resolveBusServiceId(ContainerBuilder $container, string $busId): string
+    {
+        while ($container->hasAlias($busId)) {
+            $busId = (string) $container->getAlias($busId);
+        }
+
+        return $busId;
     }
 
     /**


### PR DESCRIPTION
## Summary
- resolve messenger bus aliases before decorating handler locators so envelope aware decorators can be applied reliably

## Testing
- vendor/bin/phpunit


------
https://chatgpt.com/codex/tasks/task_e_68e2af448a8c832098452b94e18fae4c