### PR TITLE
Add message transport resolver and stamp decider

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -21,6 +21,8 @@ return static function (ContainerConfigurator $configurator): void {
             '../src/Support/DispatchAfterCurrentBusStampDecider.php',
             '../src/Support/MessageMetadataStampDecider.php',
             '../src/Support/MessageSerializerStampDecider.php',
+            '../src/Support/MessageTransportResolver.php',
+            '../src/Support/MessageTransportStampDecider.php',
             '../src/Support/StampsDecider.php',
             '../src/Support/StampDecider.php',
             '../src/Support/RetryPolicyStampDecider.php',

--- a/src/Support/MessageTransportResolver.php
+++ b/src/Support/MessageTransportResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use Psr\Container\ContainerInterface;
+
+use function get_debug_type;
+use function is_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * Resolves Messenger transport names for a given message.
+ */
+final class MessageTransportResolver
+{
+    public const DEFAULT_KEY = '__somework_cqrs_transport_default';
+
+    public function __construct(
+        private readonly ContainerInterface $transports,
+    ) {
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function resolveFor(object $message): ?array
+    {
+        $match = MessageTypeLocator::match($this->transports, $message, [self::DEFAULT_KEY]);
+
+        if (null !== $match) {
+            return $this->normaliseTransports($match->type, $match->service);
+        }
+
+        if (!$this->transports->has(self::DEFAULT_KEY)) {
+            return null;
+        }
+
+        return $this->normaliseTransports(self::DEFAULT_KEY, $this->transports->get(self::DEFAULT_KEY));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normaliseTransports(string $key, mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        } elseif (!is_array($value)) {
+            throw new \LogicException(sprintf('Transport override for "%s" must be a string or list of strings, got %s.', $key, get_debug_type($value)));
+        }
+
+        $transports = [];
+        $seen = [];
+
+        foreach ($value as $transport) {
+            if (!is_string($transport)) {
+                throw new \LogicException(sprintf('Transport override for "%s" must be a string or list of strings, got element of type %s.', $key, get_debug_type($transport)));
+            }
+
+            if (isset($seen[$transport])) {
+                continue;
+            }
+
+            $seen[$transport] = true;
+            $transports[] = $transport;
+        }
+
+        return $transports;
+    }
+}

--- a/src/Support/MessageTransportStampDecider.php
+++ b/src/Support/MessageTransportStampDecider.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Contract\Event;
+use SomeWork\CqrsBundle\Contract\Query;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+use function is_a;
+
+/**
+ * Adds transport name stamps to dispatched messages based on configuration.
+ */
+final class MessageTransportStampDecider implements StampDecider
+{
+    private const SENDERS_LOCATOR_STAMP_CLASS = 'Symfony\\Component\\Messenger\\Stamp\\SendersLocatorStamp';
+    private const SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS = 'Symfony\\Component\\Messenger\\Stamp\\SendMessageToTransportsStamp';
+
+    public function __construct(
+        private readonly MessageTransportResolver $commandTransports,
+        private readonly MessageTransportResolver $commandAsyncTransports,
+        private readonly MessageTransportResolver $queryTransports,
+        private readonly MessageTransportResolver $eventTransports,
+        private readonly MessageTransportResolver $eventAsyncTransports,
+    ) {
+    }
+
+    /**
+     * @param list<StampInterface> $stamps
+     *
+     * @return list<StampInterface>
+     */
+    public function decide(object $message, DispatchMode $mode, array $stamps): array
+    {
+        foreach ($stamps as $stamp) {
+            if ($stamp instanceof TransportNamesStamp
+                || is_a($stamp, self::SENDERS_LOCATOR_STAMP_CLASS, false)
+                || is_a($stamp, self::SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS, false)) {
+                return $stamps;
+            }
+        }
+
+        $resolver = $this->resolverFor($message, $mode);
+
+        if (null === $resolver) {
+            return $stamps;
+        }
+
+        $transports = $resolver->resolveFor($message);
+
+        if (null === $transports || [] === $transports) {
+            return $stamps;
+        }
+
+        $stamps[] = new TransportNamesStamp($transports);
+
+        return $stamps;
+    }
+
+    private function resolverFor(object $message, DispatchMode $mode): ?MessageTransportResolver
+    {
+        if ($message instanceof Command) {
+            return DispatchMode::ASYNC === $mode ? $this->commandAsyncTransports : $this->commandTransports;
+        }
+
+        if ($message instanceof Query) {
+            return $this->queryTransports;
+        }
+
+        if ($message instanceof Event) {
+            return DispatchMode::ASYNC === $mode ? $this->eventAsyncTransports : $this->eventTransports;
+        }
+
+        return null;
+    }
+}

--- a/tests/Support/MessageTransportResolverTest.php
+++ b/tests/Support/MessageTransportResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Support\MessageTransportResolver;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class MessageTransportResolverTest extends TestCase
+{
+    public function test_resolves_transports_from_class_hierarchy(): void
+    {
+        $resolver = new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static fn (): array => ['default_bus'],
+            MessageTransportResolverTestParentCommand::class => static fn (): string => 'async_commands',
+        ]));
+
+        $transports = $resolver->resolveFor(new MessageTransportResolverTestChildCommand());
+
+        self::assertSame(['async_commands'], $transports);
+    }
+
+    public function test_resolves_transports_from_interface_hierarchy(): void
+    {
+        $resolver = new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static fn (): array => ['default_bus'],
+            MessageTransportResolverTestInterface::class => static fn (): array => ['first', 'second', 'first'],
+        ]));
+
+        $transports = $resolver->resolveFor(new MessageTransportResolverTestInterfaceCommand());
+
+        self::assertSame(['first', 'second'], $transports);
+    }
+
+    public function test_falls_back_to_default_transports(): void
+    {
+        $resolver = new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static fn (): array => ['primary', 'secondary', 'primary'],
+        ]));
+
+        $transports = $resolver->resolveFor(new MessageTransportResolverTestChildCommand());
+
+        self::assertSame(['primary', 'secondary'], $transports);
+    }
+
+    public function test_returns_null_when_no_match_or_default_exists(): void
+    {
+        $resolver = new MessageTransportResolver(new ServiceLocator([]));
+
+        self::assertNull($resolver->resolveFor(new MessageTransportResolverTestChildCommand()));
+    }
+}
+
+class MessageTransportResolverTestParentCommand
+{
+}
+
+class MessageTransportResolverTestChildCommand extends MessageTransportResolverTestParentCommand
+{
+}
+
+interface MessageTransportResolverTestInterface
+{
+}
+
+class MessageTransportResolverTestInterfaceCommand implements MessageTransportResolverTestInterface
+{
+}

--- a/tests/Support/MessageTransportStampDeciderTest.php
+++ b/tests/Support/MessageTransportStampDeciderTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Support\MessageTransportResolver;
+use SomeWork\CqrsBundle\Support\MessageTransportStampDecider;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
+use SomeWork\CqrsBundle\Tests\Fixture\Message\TaskCreatedEvent;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+final class MessageTransportStampDeciderTest extends TestCase
+{
+    public function test_appends_transport_names_for_sync_command(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+
+        $commandResolver = $this->resolverForMessage(CreateTaskCommand::class, ['sync']);
+        $decider = new MessageTransportStampDecider(
+            $commandResolver,
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, []);
+
+        self::assertCount(1, $stamps);
+        self::assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+        self::assertSame(['sync'], $stamps[0]->getTransportNames());
+    }
+
+    public function test_appends_transport_names_for_async_command(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+
+        $commandResolver = $this->resolverThatShouldNotBeCalled();
+        $commandAsyncResolver = $this->resolverForMessage(CreateTaskCommand::class, ['async']);
+        $decider = new MessageTransportStampDecider(
+            $commandResolver,
+            $commandAsyncResolver,
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::ASYNC, []);
+
+        self::assertCount(1, $stamps);
+        self::assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+        self::assertSame(['async'], $stamps[0]->getTransportNames());
+    }
+
+    public function test_appends_transport_names_for_query(): void
+    {
+        $message = new FindTaskQuery('123');
+
+        $queryResolver = $this->resolverForMessage(FindTaskQuery::class, ['queries']);
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $queryResolver,
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, []);
+
+        self::assertCount(1, $stamps);
+        self::assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+        self::assertSame(['queries'], $stamps[0]->getTransportNames());
+    }
+
+    public function test_appends_transport_names_for_events(): void
+    {
+        $message = new TaskCreatedEvent('123');
+
+        $eventResolver = $this->resolverForMessage(TaskCreatedEvent::class, ['events']);
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $eventResolver,
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, []);
+
+        self::assertCount(1, $stamps);
+        self::assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+        self::assertSame(['events'], $stamps[0]->getTransportNames());
+    }
+
+    public function test_appends_transport_names_for_async_events(): void
+    {
+        $message = new TaskCreatedEvent('123');
+
+        $eventAsyncResolver = $this->resolverForMessage(TaskCreatedEvent::class, ['async_events']);
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $eventAsyncResolver,
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::ASYNC, []);
+
+        self::assertCount(1, $stamps);
+        self::assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+        self::assertSame(['async_events'], $stamps[0]->getTransportNames());
+    }
+
+    public function test_ignores_when_resolver_returns_null(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+
+        $commandResolver = new MessageTransportResolver(new ServiceLocator([]));
+        $decider = new MessageTransportStampDecider(
+            $commandResolver,
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, []);
+
+        self::assertSame([], $stamps);
+    }
+
+    public function test_ignores_when_resolver_returns_empty_list(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+
+        $commandResolver = $this->resolverForMessage(CreateTaskCommand::class, []);
+        $decider = new MessageTransportStampDecider(
+            $commandResolver,
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, []);
+
+        self::assertSame([], $stamps);
+    }
+
+    public function test_does_not_override_existing_transport_stamps(): void
+    {
+        $message = new CreateTaskCommand('123', 'Test');
+        $existing = new TransportNamesStamp(['existing']);
+
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, [$existing]);
+
+        self::assertSame([$existing], $stamps);
+    }
+
+    public function test_does_not_override_senders_locator_stamp(): void
+    {
+        $class = 'Symfony\\Component\\Messenger\\Stamp\\SendersLocatorStamp';
+        if (!class_exists($class)) {
+            self::markTestSkipped(sprintf('%s is not available in this Messenger version.', $class));
+        }
+
+        $message = new CreateTaskCommand('123', 'Test');
+        $existing = new $class([], []);
+
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, [$existing]);
+
+        self::assertSame([$existing], $stamps);
+    }
+
+    public function test_does_not_override_send_message_to_transports_stamp(): void
+    {
+        $class = 'Symfony\\Component\\Messenger\\Stamp\\SendMessageToTransportsStamp';
+        if (!class_exists($class)) {
+            self::markTestSkipped(sprintf('%s is not available in this Messenger version.', $class));
+        }
+
+        $message = new CreateTaskCommand('123', 'Test');
+        $existing = new $class(['existing']);
+
+        $decider = new MessageTransportStampDecider(
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+            $this->resolverThatShouldNotBeCalled(),
+        );
+
+        $stamps = $decider->decide($message, DispatchMode::SYNC, [$existing]);
+
+        self::assertSame([$existing], $stamps);
+    }
+
+    /**
+     * @param list<string> $transports
+     */
+    private function resolverForMessage(string $messageClass, array $transports): MessageTransportResolver
+    {
+        return new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static function (): array {
+                throw new \RuntimeException('Default transports should not be used in tests.');
+            },
+            $messageClass => static fn (): array => $transports,
+        ]));
+    }
+
+    private function resolverThatShouldNotBeCalled(): MessageTransportResolver
+    {
+        return new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static function (): array {
+                throw new \RuntimeException('This resolver should not be used.');
+            },
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary
- add a resolver that selects messenger transport names for a message using MessageTypeLocator and deduplicates results
- introduce a stamp decider that applies TransportNamesStamp based on dispatch mode while respecting existing transport stamps
- cover the new resolver and decider with unit tests and update the default service load exclusion list

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e513f46df083208a6e96f82116a442