### PR TITLE
Document transport defaults and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ somework_cqrs:
             default: sync
             map:
                 App\Domain\Event\OrderShipped: async
+    transports:
+        command:
+            default: []
+            map:
+                App\Application\Command\ShipOrder: ['sync_commands']
+        command_async:
+            default: ['async_commands']
+            map:
+                App\Application\Command\ShipOrder: ['high_priority_async_commands']
+        query:
+            default: []
+            map: {}
+        event:
+            default: []
+            map:
+                App\Domain\Event\OrderShipped: ['sync_events']
+        event_async:
+            default: ['async_events']
+            map:
+                App\Domain\Event\OrderShipped:
+                    - 'async_events'
+                    - 'audit_log'
     async:
         dispatch_after_current_bus:
             command:
@@ -210,6 +232,15 @@ messages to `false` when they should be sent immediately.
 Need additional stamps? Implement `SomeWork\CqrsBundle\Support\StampDecider`, tag
 the service with `somework_cqrs.dispatch_stamp_decider`, and the bundle will run
 it alongside the built-in `DispatchAfterCurrentBusStamp` logic.
+
+`transports` configures the Messenger transport names the bundle will attach
+via `TransportNamesStamp`. Defaults are evaluated per bus, so you can send every
+asynchronous command through `async_commands` while routing specific messages to
+`high_priority_async_commands` or mirroring events into an `audit_log` queue.
+Messenger still evaluates your `framework.messenger.routing` rules after the
+stamp is applied. Existing routes continue to work, and if callers attach their
+own `TransportNamesStamp`/`SendMessageToTransportsStamp` the bundle leaves those
+choices intact for advanced delivery strategies.
 
 ### How message overrides are resolved
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,6 +67,28 @@ somework_cqrs:
             default: sync
             map:
                 App\Domain\Event\OrderShipped: async
+    transports:
+        command:
+            default: []
+            map:
+                App\Application\Command\ShipOrder: ['sync_commands']
+        command_async:
+            default: ['async_commands']
+            map:
+                App\Application\Command\ShipOrder: ['high_priority_async_commands']
+        query:
+            default: []
+            map: {}
+        event:
+            default: []
+            map:
+                App\Domain\Event\OrderShipped: ['sync_events']
+        event_async:
+            default: ['async_events']
+            map:
+                App\Domain\Event\OrderShipped:
+                    - 'async_events'
+                    - 'audit_log'
     async:
         dispatch_after_current_bus:
             command:
@@ -120,6 +142,14 @@ somework_cqrs:
   validates this at container-compilation time and throws an
   `InvalidConfigurationException` when an async default or override exists
   without the corresponding async bus id.
+* **transports** – lists Messenger transport names that the bundle adds through
+  `TransportNamesStamp` when dispatching messages. Defaults and overrides are
+  evaluated per bus, so you can send all async commands through
+  `async_commands`, mirror specific events into `audit_log`, or leave sync buses
+  unconfigured. Messenger still applies your `framework.messenger.routing`
+  definitions after the stamp is attached, and existing routes remain intact
+  when callers provide their own `TransportNamesStamp` or
+  `SendMessageToTransportsStamp` for advanced delivery logic.
 * **async.dispatch_after_current_bus** – toggles whether the bundle appends
   Messenger's `DispatchAfterCurrentBusStamp` when a command or event resolves to
   the asynchronous bus. Leave the `default` values set to `true` to preserve the


### PR DESCRIPTION
## Summary
- extend the configuration examples with the new `transports` block covering defaults and overrides
- document how the generated transport stamps interact with Messenger routing and custom transport stamps

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e54379971883209f011dcffef4ce92