### PR TITLE
Add command to inspect CQRS transport routing

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -215,7 +215,7 @@ power diagnostics, smoke tests, or documentation pages. The registry exposes:
 
 ## Console reference
 
-Two console commands ship with the bundle:
+Three console commands ship with the bundle:
 
 * `somework:cqrs:list` – Prints the handler catalogue in a table. Accepts the
   `--type=<command|query|event>` option multiple times. Add `--details` to the
@@ -227,8 +227,12 @@ Two console commands ship with the bundle:
   * `--handler=` to customise the handler class name.
   * `--dir=` to override the base directory (defaults to `<project>/src`).
   * `--force` to overwrite existing files instead of aborting.
+* `somework:cqrs:debug-transports` – Audits the Messenger transports that CQRS
+  messages map to, showing both defaults per bus and explicit per-message
+  overrides. Run this command whenever you need to verify routing before
+  shipping configuration changes.
 
-Both commands are registered automatically when the bundle is enabled.
+All commands are registered automatically when the bundle is enabled.
 
 ### Inspecting handler configuration
 
@@ -257,3 +261,11 @@ The detailed view adds these columns to every row:
 Use this output to verify how custom overrides are applied across your
 application or to debug unexpected dispatch behaviour in production
 environments.
+
+### Auditing transport routing
+
+Run `php bin/console somework:cqrs:debug-transports` to review which Messenger
+transports each CQRS bus will target by default and to list every per-message
+override. This command surfaces the raw transport mapping compiled into the
+container, making it the canonical way to audit routing before deploying
+changes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,7 +67,7 @@ final class InvoicePaidProjector implements EventHandler
 
 ## Console tooling
 
-Two commands ship with the bundle once it is registered in your kernel:
+Three commands ship with the bundle once it is registered in your kernel:
 
 * `somework:cqrs:list` renders a table of discovered messages and their
   handlers. Use `--type=command` (or `query` / `event`) to focus the output.
@@ -76,6 +76,9 @@ Two commands ship with the bundle once it is registered in your kernel:
   to produce `ShipOrder` and `ShipOrderHandler` inside your project `src/`
   directory. Pass `--dir=app/src` and `--force` to customise the target or
   overwrite existing files.
+* `somework:cqrs:debug-transports` prints the default Messenger transports for
+  each CQRS bus alongside every explicit override so you can audit routing
+  across your application.
 
 Pass `--details` to `somework:cqrs:list` to inspect the resolved dispatch
 configuration for each handler:
@@ -135,6 +138,12 @@ to the metadata powering the CLI. It offers `all()`, `byType()`, and
 
 These commands respect the naming strategy configured for the bundle when
 presenting handler information.
+
+For transport routing specifically, rely on `bin/console
+somework:cqrs:debug-transports` as the canonical source of truth. The command
+reflects the compiled container configuration, so you can confirm which
+Messenger transports will receive your CQRS messages before rolling out
+infrastructure changes.
 
 See the [configuration reference](reference.md) for the exhaustive list of
 options you can tune.

--- a/src/Command/DebugTransportsCommand.php
+++ b/src/Command/DebugTransportsCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Command;
+
+use SomeWork\CqrsBundle\Support\TransportMappingProvider;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function implode;
+use function sprintf;
+
+use const PHP_EOL;
+
+#[AsCommand(
+    name: 'somework:cqrs:debug-transports',
+    description: 'Inspect Messenger transport routing for CQRS messages.',
+)]
+final class DebugTransportsCommand extends Command
+{
+    /**
+     * @var array<string, string>
+     */
+    private const BUS_LABELS = [
+        'command' => 'Command',
+        'command_async' => 'Command (async)',
+        'query' => 'Query',
+        'event' => 'Event',
+        'event_async' => 'Event (async)',
+    ];
+
+    public function __construct(
+        private readonly TransportMappingProvider $mappingProvider,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $table = new Table($output);
+        $table->setHeaders(['Bus', 'Default Transports', 'Explicit Overrides']);
+
+        foreach (self::BUS_LABELS as $key => $label) {
+            $mapping = $this->mappingProvider->forBus($key);
+
+            $defaults = $this->formatTransports($mapping['default']);
+            $overrides = $this->formatOverrides($mapping['map']);
+
+            $table->addRow([$label, $defaults, $overrides]);
+        }
+
+        $table->render();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $transports
+     */
+    private function formatTransports(array $transports): string
+    {
+        if ([] === $transports) {
+            return 'None';
+        }
+
+        return implode(', ', $transports);
+    }
+
+    /**
+     * @param array<class-string, list<string>> $overrides
+     */
+    private function formatOverrides(array $overrides): string
+    {
+        if ([] === $overrides) {
+            return 'None';
+        }
+
+        $rows = [];
+        foreach ($overrides as $message => $transports) {
+            $rows[] = sprintf('%s => %s', $message, $this->formatTransports($transports));
+        }
+
+        return implode(PHP_EOL, $rows);
+    }
+}

--- a/src/DependencyInjection/CqrsExtension.php
+++ b/src/DependencyInjection/CqrsExtension.php
@@ -32,6 +32,7 @@ use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Support\RetryPolicyStampDecider;
 use SomeWork\CqrsBundle\Support\StampDecider;
 use SomeWork\CqrsBundle\Support\StampsDecider;
+use SomeWork\CqrsBundle\Support\TransportMappingProvider;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -429,6 +430,14 @@ final class CqrsExtension extends Extension
         $configuredTransportNames = array_values(array_unique($configuredTransportNames));
 
         $container->setParameter('somework_cqrs.transport_names', $configuredTransportNames);
+        $container->setParameter('somework_cqrs.transport_mapping', $config);
+
+        $providerDefinition = new Definition(TransportMappingProvider::class);
+        $providerDefinition->setArgument('$mapping', $config);
+        $providerDefinition->setPublic(false);
+
+        $container->setDefinition('somework_cqrs.transport_mapping_provider', $providerDefinition);
+        $container->setAlias(TransportMappingProvider::class, 'somework_cqrs.transport_mapping_provider')->setPublic(false);
     }
 
     /**

--- a/src/Support/TransportMappingProvider.php
+++ b/src/Support/TransportMappingProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+/**
+ * @internal
+ */
+final class TransportMappingProvider
+{
+    /**
+     * @param array{
+     *     command: array{default: list<string>, map: array<class-string, list<string>>},
+     *     command_async: array{default: list<string>, map: array<class-string, list<string>>},
+     *     query: array{default: list<string>, map: array<class-string, list<string>>},
+     *     event: array{default: list<string>, map: array<class-string, list<string>>},
+     *     event_async: array{default: list<string>, map: array<class-string, list<string>>},
+     * } $mapping
+     */
+    public function __construct(
+        private readonly array $mapping,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     default: list<string>,
+     *     map: array<class-string, list<string>>,
+     * }
+     */
+    public function forBus(string $bus): array
+    {
+        return $this->mapping[$bus] ?? ['default' => [], 'map' => []];
+    }
+
+    /**
+     * @return array{
+     *     command: array{default: list<string>, map: array<class-string, list<string>>},
+     *     command_async: array{default: list<string>, map: array<class-string, list<string>>},
+     *     query: array{default: list<string>, map: array<class-string, list<string>>},
+     *     event: array{default: list<string>, map: array<class-string, list<string>>},
+     *     event_async: array{default: list<string>, map: array<class-string, list<string>>},
+     * }
+     */
+    public function all(): array
+    {
+        return $this->mapping;
+    }
+}

--- a/tests/Command/DebugTransportsCommandTest.php
+++ b/tests/Command/DebugTransportsCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Command\DebugTransportsCommand;
+use SomeWork\CqrsBundle\Support\TransportMappingProvider;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugTransportsCommandTest extends TestCase
+{
+    public function test_displays_transport_mapping_table(): void
+    {
+        $provider = new TransportMappingProvider([
+            'command' => [
+                'default' => ['sync_transport'],
+                'map' => [
+                    DebugTransportCommandMessage::class => ['async_transport'],
+                ],
+            ],
+            'command_async' => [
+                'default' => ['async_transport'],
+                'map' => [],
+            ],
+            'query' => [
+                'default' => [],
+                'map' => [
+                    DebugTransportQueryMessage::class => ['slow_transport', 'fast_transport'],
+                ],
+            ],
+            'event' => [
+                'default' => ['broadcast'],
+                'map' => [],
+            ],
+            'event_async' => [
+                'default' => [],
+                'map' => [],
+            ],
+        ]);
+
+        $tester = new CommandTester(new DebugTransportsCommand($provider));
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(SymfonyCommand::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+
+        self::assertStringContainsString('Command', $output);
+        self::assertStringContainsString('Command (async)', $output);
+        self::assertStringContainsString('Query', $output);
+        self::assertStringContainsString('Event', $output);
+        self::assertStringContainsString('Event (async)', $output);
+
+        self::assertStringContainsString('sync_transport', $output);
+        self::assertStringContainsString('async_transport', $output);
+        self::assertStringContainsString('DebugTransportCommandMessage => async_transport', $output);
+        self::assertStringContainsString('DebugTransportQueryMessage => slow_transport, fast_transport', $output);
+        self::assertStringContainsString('None', $output);
+    }
+}
+
+final class DebugTransportCommandMessage
+{
+}
+
+final class DebugTransportQueryMessage
+{
+}


### PR DESCRIPTION
## Summary
- persist the compiled Messenger transport mapping for CQRS buses and expose it via a provider service
- add the `somework:cqrs:debug-transports` console command to display default transports and overrides
- cover the new command with functional tests and document it as the recommended way to audit routing
- align the `DebugTransportsCommand` implementation with php-cs-fixer formatting expectations

## Testing
- vendor/bin/phpunit
- vendor/bin/php-cs-fixer fix --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e54adb5f988320b8888cc5b654fcc6