### PR TITLE
Allow configuring Messenger stamp type for CQRS transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,21 +175,26 @@ somework_cqrs:
                 App\Domain\Event\OrderShipped: async
     transports:
         command:
+            stamp: transport_names
             default: []
             map:
                 App\Application\Command\ShipOrder: ['sync_commands']
         command_async:
+            stamp: transport_names
             default: ['async_commands']
             map:
                 App\Application\Command\ShipOrder: ['high_priority_async_commands']
         query:
+            stamp: transport_names
             default: []
             map: {}
         event:
+            stamp: transport_names
             default: []
             map:
                 App\Domain\Event\OrderShipped: ['sync_events']
         event_async:
+            stamp: transport_names
             default: ['async_events']
             map:
                 App\Domain\Event\OrderShipped:
@@ -234,8 +239,11 @@ the service with `somework_cqrs.dispatch_stamp_decider`, and the bundle will run
 it alongside the built-in `DispatchAfterCurrentBusStamp` logic.
 
 `transports` configures the Messenger transport names the bundle will attach
-via `TransportNamesStamp`. Defaults are evaluated per bus, so you can send every
-asynchronous command through `async_commands` while routing specific messages to
+via `TransportNamesStamp` by default. Each bus accepts an optional `stamp`
+setting to swap the behaviour to Messenger's `SendMessageToTransportsStamp`
+when running on Symfony 6.3+ (older releases trigger a descriptive exception).
+Defaults are evaluated per bus, so you can send every asynchronous command
+through `async_commands` while routing specific messages to
 `high_priority_async_commands` or mirroring events into an `audit_log` queue.
 Messenger still evaluates your `framework.messenger.routing` rules after the
 stamp is applied. Existing routes continue to work, and if callers attach their

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -69,21 +69,26 @@ somework_cqrs:
                 App\Domain\Event\OrderShipped: async
     transports:
         command:
+            stamp: transport_names
             default: []
             map:
                 App\Application\Command\ShipOrder: ['sync_commands']
         command_async:
+            stamp: transport_names
             default: ['async_commands']
             map:
                 App\Application\Command\ShipOrder: ['high_priority_async_commands']
         query:
+            stamp: transport_names
             default: []
             map: {}
         event:
+            stamp: transport_names
             default: []
             map:
                 App\Domain\Event\OrderShipped: ['sync_events']
         event_async:
+            stamp: transport_names
             default: ['async_events']
             map:
                 App\Domain\Event\OrderShipped:
@@ -143,13 +148,17 @@ somework_cqrs:
   `InvalidConfigurationException` when an async default or override exists
   without the corresponding async bus id.
 * **transports** – lists Messenger transport names that the bundle adds through
-  `TransportNamesStamp` when dispatching messages. Defaults and overrides are
-  evaluated per bus, so you can send all async commands through
-  `async_commands`, mirror specific events into `audit_log`, or leave sync buses
-  unconfigured. Messenger still applies your `framework.messenger.routing`
-  definitions after the stamp is attached, and existing routes remain intact
-  when callers provide their own `TransportNamesStamp` or
-  `SendMessageToTransportsStamp` for advanced delivery logic.
+  `TransportNamesStamp` when dispatching messages. Each bus accepts an optional
+  `stamp` option that switches to Messenger's `SendMessageToTransportsStamp`
+  (available starting in Symfony Messenger 6.3). Selecting `send_message` on an
+  older release triggers a descriptive exception so you can upgrade the
+  dependency. Defaults and overrides are evaluated per bus, so you can send all
+  async commands through `async_commands`, mirror specific events into
+  `audit_log`, or leave sync buses unconfigured. Messenger still applies your
+  `framework.messenger.routing` definitions after the stamp is attached, and
+  existing routes remain intact when callers provide their own
+  `TransportNamesStamp` or `SendMessageToTransportsStamp` for advanced delivery
+  logic.
 * **async.dispatch_after_current_bus** – toggles whether the bundle appends
   Messenger's `DispatchAfterCurrentBusStamp` when a command or event resolves to
   the asynchronous bus. Leave the `default` values set to `true` to preserve the

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -355,6 +355,12 @@ final class Configuration implements ConfigurationInterface
 
         $children = $node->children();
 
+        $children
+            ->enumNode('stamp')
+            ->values(['transport_names', 'send_message'])
+            ->defaultValue('transport_names')
+            ->info(sprintf('Messenger stamp type to apply for %s messages.', $label));
+
         $default = $children->arrayNode('default');
         $default
             ->beforeNormalization()

--- a/src/Support/MessageTransportStampFactory.php
+++ b/src/Support/MessageTransportStampFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Support;
+
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+use function class_exists;
+use function sprintf;
+
+final class MessageTransportStampFactory
+{
+    public const TYPE_TRANSPORT_NAMES = 'transport_names';
+    public const TYPE_SEND_MESSAGE = 'send_message';
+    public const SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS = 'Symfony\\Component\\Messenger\\Stamp\\SendMessageToTransportsStamp';
+    private const SEND_MESSAGE_NOT_AVAILABLE_MESSAGE = 'The "send_message" transport stamp type requires the "%s" class. Upgrade symfony/messenger to a version that provides it.';
+
+    /**
+     * @param list<string> $transports
+     */
+    public function create(string $type, array $transports): StampInterface
+    {
+        return match ($type) {
+            self::TYPE_TRANSPORT_NAMES => new TransportNamesStamp($transports),
+            self::TYPE_SEND_MESSAGE => $this->createSendMessageStamp($transports),
+            default => throw new InvalidArgumentException(sprintf('Unknown transport stamp type "%s".', $type)),
+        };
+    }
+
+    /**
+     * @param list<string> $transports
+     */
+    private function createSendMessageStamp(array $transports): StampInterface
+    {
+        $class = self::SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS;
+
+        if (!class_exists($class)) {
+            throw new LogicException(sprintf(self::SEND_MESSAGE_NOT_AVAILABLE_MESSAGE, $class));
+        }
+
+        return new $class($transports);
+    }
+}

--- a/src/Support/StampsDecider.php
+++ b/src/Support/StampsDecider.php
@@ -84,6 +84,9 @@ final class StampsDecider implements StampDecider
         return array_values($stamps);
     }
 
+    /**
+     * @param array<string, string> $transportStampTypes
+     */
     public static function withDefaultsFor(
         string $messageType,
         RetryPolicyResolver $retryPolicies,
@@ -92,15 +95,22 @@ final class StampsDecider implements StampDecider
         ?DispatchAfterCurrentBusDecider $dispatchAfter = null,
         ?MessageTransportResolver $transports = null,
         ?MessageTransportResolver $asyncTransports = null,
+        ?MessageTransportStampFactory $transportStampFactory = null,
+        array $transportStampTypes = [],
     ): self {
+        $transportStampFactory ??= new MessageTransportStampFactory();
+        $stampTypes = array_replace(MessageTransportStampDecider::DEFAULT_STAMP_TYPES, $transportStampTypes);
+
         $deciders = [
             new RetryPolicyStampDecider($retryPolicies, $messageType),
             new MessageTransportStampDecider(
+                $transportStampFactory,
                 Command::class === $messageType ? $transports : null,
                 Command::class === $messageType ? $asyncTransports : null,
                 Query::class === $messageType ? $transports : null,
                 Event::class === $messageType ? $transports : null,
                 Event::class === $messageType ? $asyncTransports : null,
+                $stampTypes,
             ),
             new MessageSerializerStampDecider($serializers, $messageType),
             new MessageMetadataStampDecider($metadata, $messageType),

--- a/tests/Bus/CommandBusTest.php
+++ b/tests/Bus/CommandBusTest.php
@@ -17,6 +17,7 @@ use SomeWork\CqrsBundle\Support\MessageSerializerResolver;
 use SomeWork\CqrsBundle\Support\MessageSerializerStampDecider;
 use SomeWork\CqrsBundle\Support\MessageTransportResolver;
 use SomeWork\CqrsBundle\Support\MessageTransportStampDecider;
+use SomeWork\CqrsBundle\Support\MessageTransportStampFactory;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Support\RetryPolicyStampDecider;
@@ -652,6 +653,7 @@ final class CommandBusTest extends TestCase
         return new StampsDecider([
             new RetryPolicyStampDecider($retryPolicies, CommandContract::class),
             new MessageTransportStampDecider(
+                new MessageTransportStampFactory(),
                 $transports,
                 $asyncTransports,
                 null,

--- a/tests/Bus/EventBusTest.php
+++ b/tests/Bus/EventBusTest.php
@@ -17,6 +17,7 @@ use SomeWork\CqrsBundle\Support\MessageSerializerResolver;
 use SomeWork\CqrsBundle\Support\MessageSerializerStampDecider;
 use SomeWork\CqrsBundle\Support\MessageTransportResolver;
 use SomeWork\CqrsBundle\Support\MessageTransportStampDecider;
+use SomeWork\CqrsBundle\Support\MessageTransportStampFactory;
 use SomeWork\CqrsBundle\Support\NullMessageSerializer;
 use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Support\RetryPolicyStampDecider;
@@ -629,6 +630,7 @@ final class EventBusTest extends TestCase
         return new StampsDecider([
             new RetryPolicyStampDecider($retryPolicies, EventContract::class),
             new MessageTransportStampDecider(
+                new MessageTransportStampFactory(),
                 null,
                 null,
                 null,

--- a/tests/DependencyInjection/CqrsExtensionTransportsTest.php
+++ b/tests/DependencyInjection/CqrsExtensionTransportsTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
 use SomeWork\CqrsBundle\DependencyInjection\CqrsExtension;
 use SomeWork\CqrsBundle\Support\MessageTransportStampDecider;
+use SomeWork\CqrsBundle\Support\MessageTransportStampFactory;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\FindTaskQuery;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\GenerateReportCommand;
@@ -79,6 +80,17 @@ final class CqrsExtensionTransportsTest extends TestCase
 
         $decider = $container->get('somework_cqrs.stamp_decider.message_transport');
         self::assertInstanceOf(MessageTransportStampDecider::class, $decider);
+
+        self::assertSame(
+            [
+                'command' => MessageTransportStampFactory::TYPE_TRANSPORT_NAMES,
+                'command_async' => MessageTransportStampFactory::TYPE_TRANSPORT_NAMES,
+                'query' => MessageTransportStampFactory::TYPE_TRANSPORT_NAMES,
+                'event' => MessageTransportStampFactory::TYPE_TRANSPORT_NAMES,
+                'event_async' => MessageTransportStampFactory::TYPE_TRANSPORT_NAMES,
+            ],
+            $container->getParameter('somework_cqrs.transport_stamp_types'),
+        );
 
         $overrideCommand = new CreateTaskCommand('id', 'name');
         $this->assertTransportNames(

--- a/tests/Fixture/Messenger/SendMessageToTransportsStampStub.php
+++ b/tests/Fixture/Messenger/SendMessageToTransportsStampStub.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Stamp;
+
+if (!class_exists('Symfony\\Component\\Messenger\\Stamp\\SendMessageToTransportsStamp')) {
+    final class SendMessageToTransportsStamp implements StampInterface
+    {
+        /**
+         * @param list<string> $transports
+         */
+        public function __construct(private readonly array $transports)
+        {
+        }
+
+        /**
+         * @return list<string>
+         */
+        public function getTransports(): array
+        {
+            return $this->transports;
+        }
+
+        /**
+         * @return list<string>
+         */
+        public function getTransportNames(): array
+        {
+            return $this->transports;
+        }
+    }
+}

--- a/tests/Support/MessageTransportStampFactoryTest.php
+++ b/tests/Support/MessageTransportStampFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\CqrsBundle\Tests\Support;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use SomeWork\CqrsBundle\Support\MessageTransportStampFactory;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+final class MessageTransportStampFactoryTest extends TestCase
+{
+    public function test_creates_transport_names_stamp(): void
+    {
+        $factory = new MessageTransportStampFactory();
+
+        $stamp = $factory->create(MessageTransportStampFactory::TYPE_TRANSPORT_NAMES, ['default']);
+
+        self::assertInstanceOf(TransportNamesStamp::class, $stamp);
+        self::assertSame(['default'], $stamp->getTransportNames());
+    }
+
+    public function test_throws_when_send_message_stamp_missing(): void
+    {
+        if (class_exists(MessageTransportStampFactory::SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS)) {
+            self::markTestSkipped('SendMessageToTransportsStamp is available, cannot assert exception.');
+        }
+
+        $factory = new MessageTransportStampFactory();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('SendMessageToTransportsStamp');
+
+        $factory->create(MessageTransportStampFactory::TYPE_SEND_MESSAGE, ['async']);
+    }
+
+    #[RunInSeparateProcess]
+    public function test_creates_send_message_stamp_when_available(): void
+    {
+        require_once __DIR__.'/../Fixture/Messenger/SendMessageToTransportsStampStub.php';
+
+        $factory = new MessageTransportStampFactory();
+
+        $stamp = $factory->create(MessageTransportStampFactory::TYPE_SEND_MESSAGE, ['async']);
+
+        $class = MessageTransportStampFactory::SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS;
+        self::assertInstanceOf($class, $stamp);
+
+        $getter = method_exists($stamp, 'getTransportNames') ? 'getTransportNames' : 'getTransports';
+
+        /** @var callable(): array $callable */
+        $callable = [$stamp, $getter];
+
+        self::assertSame(['async'], $callable());
+    }
+}

--- a/tests/Support/StampsDeciderTest.php
+++ b/tests/Support/StampsDeciderTest.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace SomeWork\CqrsBundle\Tests\Support;
 
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use SomeWork\CqrsBundle\Bus\DispatchMode;
+use SomeWork\CqrsBundle\Contract\Command;
+use SomeWork\CqrsBundle\Support\DispatchAfterCurrentBusDecider;
+use SomeWork\CqrsBundle\Support\MessageMetadataProviderResolver;
+use SomeWork\CqrsBundle\Support\MessageSerializerResolver;
+use SomeWork\CqrsBundle\Support\MessageTransportResolver;
+use SomeWork\CqrsBundle\Support\MessageTransportStampFactory;
+use SomeWork\CqrsBundle\Support\RetryPolicyResolver;
 use SomeWork\CqrsBundle\Support\StampDecider;
 use SomeWork\CqrsBundle\Support\StampsDecider;
 use SomeWork\CqrsBundle\Tests\Fixture\DummyStamp;
 use SomeWork\CqrsBundle\Tests\Fixture\Message\CreateTaskCommand;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class StampsDeciderTest extends TestCase
 {
@@ -43,5 +52,31 @@ final class StampsDeciderTest extends TestCase
         self::assertSame('base', $stamps[0]->name);
         self::assertSame('first', $stamps[1]->name);
         self::assertSame('second', $stamps[2]->name);
+    }
+
+    #[RunInSeparateProcess]
+    public function test_with_defaults_for_emits_send_message_stamp_when_configured(): void
+    {
+        require_once __DIR__.'/../Fixture/Messenger/SendMessageToTransportsStampStub.php';
+
+        $transports = new MessageTransportResolver(new ServiceLocator([
+            MessageTransportResolver::DEFAULT_KEY => static fn (): array => ['configured'],
+        ]));
+
+        $decider = StampsDecider::withDefaultsFor(
+            messageType: Command::class,
+            retryPolicies: RetryPolicyResolver::withoutOverrides(),
+            serializers: MessageSerializerResolver::withoutOverrides(),
+            metadata: MessageMetadataProviderResolver::withoutOverrides(),
+            dispatchAfter: DispatchAfterCurrentBusDecider::defaults(),
+            transports: $transports,
+            transportStampFactory: new MessageTransportStampFactory(),
+            transportStampTypes: ['command' => MessageTransportStampFactory::TYPE_SEND_MESSAGE],
+        );
+
+        $stamps = $decider->decide(new CreateTaskCommand('1', 'Test'), DispatchMode::SYNC, []);
+
+        $class = MessageTransportStampFactory::SEND_MESSAGE_TO_TRANSPORTS_STAMP_CLASS;
+        self::assertInstanceOf($class, $stamps[0]);
     }
 }


### PR DESCRIPTION
## Summary
- add a `transports.<bus>.stamp` option and persist the per-bus selection so transport stamp types can be configured
- introduce a MessageTransportStampFactory and refactor the transport stamp decider helpers to build the appropriate Messenger stamp with validation
- extend unit tests and documentation to cover both transport stamp types and the new configuration surface

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e5515c8e8483209147db4bdf59b3b5